### PR TITLE
feat: Adding deviceId, matchConfidence to Requests

### DIFF
--- a/packages/stentor-models/src/Request/IntentRequest.ts
+++ b/packages/stentor-models/src/Request/IntentRequest.ts
@@ -68,7 +68,13 @@ export interface RequestSlot<T = RequestSlotValues> {
     successfulMatch?: boolean;
 }
 
+/**
+ * Map of slots where the key is the name of the slot.
+ */
 export interface RequestSlotMap {
+    /**
+     * Each key is the slot name and the corresponding value is the slot.
+     */
     [slotName: string]: RequestSlot;
 }
 
@@ -78,12 +84,40 @@ export interface RequestSlotMap {
  * For Alexa see {@link https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/handling-requests-sent-by-alexa#intentrequest}
  */
 export interface IntentRequest extends BaseRequest {
+    /**
+     * The type of an intent request is always "INTENT_REQUEST"
+     */
     type: IntentRequestType;
+    /**
+     * The ID of the matched intent.
+     */
     intentId: string;
+    /**
+     * The ID of the user's current session.
+     * 
+     * A session is typically defined by the channel is on but it is typically a set
+     * of requests and responses that are linked together. 
+     */
     sessionId: string;
+    /**
+     * Slots for the intent.
+     */
     slots?: RequestSlotMap;
+    /**
+     * Confidence level of the intent match.  On a scale from 0-1 where 1 is the highest confidence of a match.
+     */
+    matchConfidence?: number;
     isBargeIn?: boolean;
+    /**
+     * A meta, preliminary request that is more for understanding if the assistant can provide an answer or not.
+     */
     canFulfill?: boolean;
+    /**
+     * Optional data that can be added to the request
+     */
     data?: Data;
+    /**
+     * A unique request provided by a question answering system.  
+     */
     knowledgeAnswer?: KnowledgeAnswer;
 }

--- a/packages/stentor-models/src/Request/Request.ts
+++ b/packages/stentor-models/src/Request/Request.ts
@@ -31,6 +31,10 @@ export interface BaseRequest {
      */
     userId: string;
     /**
+     * Unique identifier provided by the channel for the user's current device.
+     */
+    deviceId?: string;
+    /**
      * The user is anonymous, or a guest.
      *
      * The user either does not yet have a verified identity or have


### PR DESCRIPTION
Adds an optional `deviceId` field to the BaseRequest to start passing this through on channels where it is available.  Also adds a `matchConfidence` field to the IntentRequest to provide the intent's confidence when available.

And some docs.