### PR TITLE
fix: Reconfigure Renovate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,4 +165,5 @@ workflows:
           requires:
             - build
             - lint
+            - test
           context: publish-packages

--- a/renovate.json
+++ b/renovate.json
@@ -7,15 +7,14 @@
       "automerge": true
     },
     {
-      "packagePatterns": ["stentor"],
-      "groupName": "stentor",
+      "packagePatterns": ["stentor", "@xapp"],
+      "groupName": "@xapp/stentor",
       "schedule": null,
       "automerge": true
     },
     {
-      "packagePatterns": ["@xapp"],
-      "schedule": null,
-      "automerge": true
+      "packageNames": ["aws-sdk"],
+      "schedule": ["after 9pm on sunday"]
     }
   ]
 }


### PR DESCRIPTION
Updates the renovate config to only update aws-sdk once a week and combines all stentor & @xapp packages into one group and also fixes the circle config to ensure tests are run before release.