### PR TITLE
fix: Crash within AbstractHandler.canHandlerInputUnknown when handler data is undefined

### DIFF
--- a/packages/stentor-handler/src/AbstractHandler/Handler.ts
+++ b/packages/stentor-handler/src/AbstractHandler/Handler.ts
@@ -158,12 +158,12 @@ export abstract class AbstractHandler<
             hasPreviousRepromptResponse = true;
         }
 
-        if (this.data.inputUnknownStrategy === INPUT_UNKNOWN_STRATEGY_REPROMPT && hasPreviousRepromptResponse) {
+        if (typeof this.data === "object" && this.data.inputUnknownStrategy === INPUT_UNKNOWN_STRATEGY_REPROMPT && hasPreviousRepromptResponse) {
             // we need a reprompt
             canHandleInputUnknown = true;
         }
 
-        if (this.data.inputUnknownStrategy === INPUT_UNKNOWN_STRATEGY_GOOGLE && hasPreviousRepromptResponse) {
+        if (typeof this.data === "object" && this.data.inputUnknownStrategy === INPUT_UNKNOWN_STRATEGY_GOOGLE && hasPreviousRepromptResponse) {
             canHandleInputUnknown = true;
         }
 

--- a/packages/stentor-handler/src/AbstractHandler/Handler.ts
+++ b/packages/stentor-handler/src/AbstractHandler/Handler.ts
@@ -28,16 +28,6 @@ import { INPUT_UNKNOWN_STRATEGY_GOOGLE, INPUT_UNKNOWN_STRATEGY_REPROMPT } from "
  * The AbstractHandler takes in intents and translates them to responses.
  *
  * All handlers must extend the AbstractHandler.
- *
- * @export
- * @abstract
- * @class Handler
- * @implements {RequestHandler}
- * @implements {Handler<T>}
- * @template T
- * @template Content
- * @template D
- * @template Data
  */
 export abstract class AbstractHandler<
     C extends Content = Content,
@@ -45,6 +35,7 @@ export abstract class AbstractHandler<
     F extends Forward = Forward,
     R extends Redirect = Redirect
     > implements RequestHandler, Handler<C, D, F, R> {
+
     public readonly type: string;
 
     public readonly intentId: string;

--- a/packages/stentor-handler/src/AbstractHandler/__test__/Handler.test.ts
+++ b/packages/stentor-handler/src/AbstractHandler/__test__/Handler.test.ts
@@ -736,6 +736,20 @@ describe("AbstractHandler", () => {
                 data: {}
             });
         });
+        describe("when data is undefined", () => {
+            it('returns false', () => {
+                request = new IntentRequestBuilder().withIntentId("foo").build();
+                context = new ContextBuilder().build();
+                expect(new TestHandler({
+                    appId,
+                    organizationId,
+                    intentId,
+                    type: BASE_HANDLER_TYPE,
+                    content: {},
+                    forward
+                }).canHandleInputUnknown(request, context)).to.be.false;
+            });
+        });
         describe("without an input unknown strategy", () => {
             it("returns false", () => {
                 request = new IntentRequestBuilder().withIntentId("foo").build();


### PR DESCRIPTION
This fixes a crash that was observed when the handler does not yet have anything on the data field.