### PR TITLE
fix: Adding isDuration

### DIFF
--- a/packages/stentor-utils/src/date-time/__test__/isDuration.test.ts
+++ b/packages/stentor-utils/src/date-time/__test__/isDuration.test.ts
@@ -1,0 +1,13 @@
+/*! Copyright (c) 2020, XAPPmedia */
+import { expect } from "chai";
+
+import { isDuration } from "../isDuration";
+
+describe(`#${isDuration.name}()`, () => {
+    it('returns the correct value', () => {
+        expect(isDuration("foo")).to.be.false;
+        expect(isDuration(undefined)).to.be.false;
+        expect(isDuration({ amount: 4, format: "m" })).to.be.true;
+        expect(isDuration(['foo', 'boo'])).to.be.false;
+    });
+});

--- a/packages/stentor-utils/src/date-time/index.ts
+++ b/packages/stentor-utils/src/date-time/index.ts
@@ -2,4 +2,5 @@
 export * from "./addDurations";
 export * from "./durationFormatGreaterThan";
 export * from "./getDurationFrom";
+export * from "./isDuration";
 export * from "./isISO8601Duration";

--- a/packages/stentor-utils/src/date-time/isDuration.ts
+++ b/packages/stentor-utils/src/date-time/isDuration.ts
@@ -1,0 +1,12 @@
+/*! Copyright (c) 2020, XAPPmedia */
+import { Duration, RequestSlotValues } from "stentor-models";
+
+/**
+ * Determine if the request slot value is a Duration
+ *
+ * @public
+ * @param slotValue - Slot value to check 
+ */
+export function isDuration(slotValue: RequestSlotValues): slotValue is Duration {
+    return !!slotValue && typeof slotValue === "object" && typeof (slotValue as Duration).amount === "number" && typeof (slotValue as Duration).format === "string";
+}

--- a/packages/stentor-utils/src/dateTime.ts
+++ b/packages/stentor-utils/src/dateTime.ts
@@ -1,5 +1,5 @@
 /*! Copyright (c) 2019, XAPPmedia */
-import { DateTime, DateTimeRange, RelativeDateRangeType, RelativeDateType } from "stentor-models";
+import { DateTime, DateTimeRange, RelativeDateRangeType, RelativeDateType, RequestSlotValues } from "stentor-models";
 import {
     addDays,
     addMonths,
@@ -27,25 +27,23 @@ export const ISO_8601_DATE_ONLY = /\d{4}-\d{2}-\d{2}/;
 export const ISO_8601_TIME_ONLY = /(\d{2}:\d{2}:\d{2})(?:-\d{2}:\d{2})?/;
 
 /**
- * Used on a RequestSlot.dateTime to determine if it is just dateTime or a range.
+ * Determine if the request slot value is a DateTime
  *
- * @export
- * @param {(DateTime | DateTimeRange)} item
- * @returns {item is DateTime}
+ * @public
+ * @param slotValue - Slot value to check 
  */
-export function isDateTime(item: DateTime | DateTimeRange): item is DateTime {
-    return !!item && (!!(item as DateTime).date || !!(item as DateTime).time);
+export function isDateTime(slotValue: RequestSlotValues): slotValue is DateTime {
+    return !!slotValue && (!!(slotValue as DateTime).date || !!(slotValue as DateTime).time);
 }
 
 /**
- * Used on a RequestSlot.dateTime to determine if it is just dateTime or a range.
+ * Determine if the request slot value is a DateTimeRange
  *
- * @export
- * @param {(DateTime | DateTimeRange)} item
- * @returns {item is DateTimeRange}
+ * @public
+ * @param slotValue - Slot value to check
  */
-export function isDateTimeRange(item: DateTime | DateTimeRange): item is DateTimeRange {
-    return !!item && (!!(item as DateTimeRange).start || !!(item as DateTimeRange).end);
+export function isDateTimeRange(slotValue: RequestSlotValues): slotValue is DateTimeRange {
+    return !!slotValue && (!!(slotValue as DateTimeRange).start || !!(slotValue as DateTimeRange).end);
 }
 
 /**
@@ -53,7 +51,7 @@ export function isDateTimeRange(item: DateTime | DateTimeRange): item is DateTim
  *
  * Either a single date (2020-07-19T23:59:59) or a range (2019-07-19T00:00:00 --> 2020-07-19T23:59:59).
  *
- * @param dateTime
+ * @param dateTime - Either DateTime or DateTimeRange to convert to a string
  */
 export function dateTimeToString(dateTime: DateTime | DateTimeRange): string {
     if (typeof dateTime !== "object") {
@@ -187,7 +185,7 @@ export function getDateTimeFrom(date: string | Date, includeOnly?: "time" | "dat
             }
         }
     } else {
-        // Not a typical ISO from dialogflow, going to try to pull out the individual components
+        // Not a typical ISO from Dialogflow, going to try to pull out the individual components
         // First date.
         const dateRegex = new RegExp(ISO_8601_DATE_ONLY);
         const dateResults = dateRegex.exec(dateTime);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,10 +1976,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@2.643.0:
-  version "2.643.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.643.0.tgz#0b4cc49165a25c42ab0503580806d367d32ffb88"
-  integrity sha512-4r7VGQFqshrhXnOCVQdlatAWiK/8kmmtAtY9gbITPNpY5Is+SfIy6k/1BgrnL5H/2sYd27H+Xp8itXZoCnQeTw==
+aws-sdk@2.648.0:
+  version "2.648.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.648.0.tgz#6cbea887b98c3ee8316870e9eead659194e35094"
+  integrity sha512-b+PdZmCFvZBisqXEH68jO4xB30LrDHQMWrEX6MJoZaOlxPJfpOqRFUH3zsiAXF5Q2jTdjYLtS5bs3vcIwRzi3Q==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -6894,10 +6894,10 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rollup@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.2.0.tgz#d82cfd6eda6d9561593a7e8a2fc0b72811a89b49"
-  integrity sha512-iAu/j9/WJ0i+zT0sAMuQnsEbmOKzdQ4Yxu5rbPs9aUCyqveI1Kw3H4Fi9NWfCOpb8luEySD2lDyFWL9CrLE8iw==
+rollup@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.3.0.tgz#0b9e1c19bea22464958854dae646b8b40d2d3ed5"
+  integrity sha512-nIq2Z9YwNbEfqTlAXe/tVl8CwUsjX/8Q5Jxlx+JRoYCu5keKLc6k0zyt11sM6WtCDxhmmJEIosFy9y26ZFRx6w==
   optionalDependencies:
     fsevents "~2.1.2"
 


### PR DESCRIPTION
Adds new type guard `isDuration` and modifies `isDateTime` and `isDateTimeRange` to make it slightly easier to consume.