### PR TITLE
fix: Require id on channel & nlu data models

### DIFF
--- a/packages/stentor-models/src/Channel/ChannelData.ts
+++ b/packages/stentor-models/src/Channel/ChannelData.ts
@@ -9,7 +9,7 @@ export interface ChannelData {
     /**
      * Unique ID of the channel.
      */
-    id?: string;
+    id: string;
     /**
      * The channel type
      */

--- a/packages/stentor-models/src/NLU/NLUData.ts
+++ b/packages/stentor-models/src/NLU/NLUData.ts
@@ -3,7 +3,7 @@ export interface NLUData {
     /**
      * The reference ID for the NLU
      */
-    id?: string;
+    id: string;
     /**
      * The type of NLU
      */


### PR DESCRIPTION
A channel or nlu data needs an ID to help identify it in other operations. 