### PR TITLE
fix: Remove older node version in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    # node 10.16.0 is our lambda node version
     - image: circleci/node:10.20.1
 
 jobs:
@@ -93,10 +92,7 @@ jobs:
           command: yarn license-check
 
   release:
-    working_directory: ~/repo
-    docker:
-      # semantic-release requires node 8.3
-      - image: circleci/node:8.17
+    <<: *defaults
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This should fix the release build on circle, this setting was unnecessary since we don't use semantic-release.