### PR TITLE
feat: Ability to override entity type on Slot & Entity for a specified NLU

### DIFF
--- a/packages/stentor-models/src/Entity/Entity.ts
+++ b/packages/stentor-models/src/Entity/Entity.ts
@@ -17,11 +17,19 @@ export interface Entity {
      */
     entityId: string;
     /**
+     * NLU specific metadata used when translating to the NLU entity.
+     * 
+     * Use it to override the entity type for a specific NLU
+     */
+    nlu?: { [nlu: string]: { type: string } };
+    /**
      * Optional display name, used to help better communicate the entity.
      */
     displayName?: string;
     /**
      * Optional ID if the slot type has a representation in Dialogflow.
+     * 
+     * @deprecated This field is being phased out.
      */
     dialogflowId?: string;
     /**

--- a/packages/stentor-models/src/Intent/Intent.ts
+++ b/packages/stentor-models/src/Intent/Intent.ts
@@ -35,6 +35,8 @@ export interface Intent extends Localizable<LocaleSpecificIntent> {
     intentId: string;
     /**
      * Dialogflow keeps track of individual intents by a unique ID.
+     * 
+     * @deprecated This field is being phased out. 
      */
     dialogflowId?: string;
     /**

--- a/packages/stentor-models/src/Request/IntentRequest.ts
+++ b/packages/stentor-models/src/Request/IntentRequest.ts
@@ -4,7 +4,7 @@ import { Data } from "../Handler";
 import { BaseRequest } from "./Request";
 import { IntentRequestType } from "./Types";
 
-export type RequestSlotValues = string | number | DateTimeRange | DateTime | Duration | (string)[];
+export type RequestSlotValues = string | number | object | DateTimeRange | DateTime | Duration | (string)[];
 
 export interface KnowledgeAnswer {
     /**

--- a/packages/stentor-models/src/Slot/Slot.ts
+++ b/packages/stentor-models/src/Slot/Slot.ts
@@ -19,7 +19,13 @@ export interface Slot {
      *
      * For legacy applications, SlotType is used.
      */
-    type: string;
+    type?: string;
+    /**
+     * NLU specific metadata used when translating to the NLU entity.
+     * 
+     * Use to override the type for a specific NLU. 
+     */
+    nlu?: { [nlu: string]: { type: string } };
     /**
      * Is the slot a list of values.
      * 


### PR DESCRIPTION
This adds the `nlu` field to both a Slot and Entity to allow for overriding the type for a specific NLU.

This field will be taken into account at the time of model translation when updating the NLU.

This will allow models to contain a broader set of entities, those that do not have a abstracted version in stentor.