### PR TITLE
fix: Adds basic Lambda Context Util

### DIFF
--- a/packages/stentor-models/src/Runtime/RuntimeContext.ts
+++ b/packages/stentor-models/src/Runtime/RuntimeContext.ts
@@ -30,7 +30,7 @@ export interface RuntimeContext {
     /**
      * Current environment
      */
-    environment?: "dev" | "stage" | "prod" | "production";
+    environment?: "dev" | "stage" | "prod" | "production" | string;
     /**
      * The request body as a string.
      *

--- a/packages/stentor-runtime/src/ContextUtils.ts
+++ b/packages/stentor-runtime/src/ContextUtils.ts
@@ -173,3 +173,25 @@ export function lambdaAPIGatewayContext(
 
     return { event, context };
 }
+
+/**
+ * Context for accessing a lambda directly
+ */
+export function lambdaContext(
+    lambdaEvent: object,
+    lambdaContext: LambdaContext
+): { event: object; context: RuntimeContext } {
+
+    const event = lambdaEvent;
+
+    const context: RuntimeContext = {};
+
+    context.getRemainingTimeInMillis = lambdaContext.getRemainingTimeInMillis;
+    context.environment = process.env.NODE_ENV;
+
+    context.buildResponse = (code: number, result: object): object => {
+        return result;
+    };
+
+    return { event, context }
+}

--- a/packages/stentor-runtime/src/translateEventAndContext.ts
+++ b/packages/stentor-runtime/src/translateEventAndContext.ts
@@ -17,7 +17,7 @@ export function translateEventAndContext(event: any, context: any): { event: obj
     } else if (event.testContext) {
         translated = virtualBstContext(event);
     } else if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
-        translated = lambdaContext(event, translated);
+        translated = lambdaContext(event, context);
     } else {
         // Default to a simple pass through
         translated.context.buildResponse.buildResponse = (code: number, result: object): object => {


### PR DESCRIPTION
We didn't return a response when sending events directly to a lambda (never did it before, it was always through API Gateway), this adds a basic lambdaContext util.