### PR TITLE
feat: Adds NLU key value store on Intent model 

### DIFF
--- a/packages/stentor-models/src/Intent/Intent.ts
+++ b/packages/stentor-models/src/Intent/Intent.ts
@@ -108,6 +108,12 @@ export interface Intent extends Localizable<LocaleSpecificIntent> {
      */
     defaultLocale?: Locale;
     /**
+     * NLU specific metadata used when translating the intentId to a NLU specific type.
+     * 
+     * Use to override the type for a specific NLU. 
+     */
+    nlu?: { [nlu: string]: { type: string } };
+    /**
      * This is a series of locales that the apps supports.  These can override the
      * items that are in the original Intent.  The items in the main intent are used as defaults if they
      * are not provided by this locale.


### PR DESCRIPTION
Similar to the slot model, adding a key value store on the Intent model allows us to do intent specific overrides on the type of intent it will be translated to for the respective NLU (which is the key in the store).