### PR TITLE
fix: Add CORS Header for API Gateway Response

### DIFF
--- a/packages/stentor-runtime/src/ContextUtils.ts
+++ b/packages/stentor-runtime/src/ContextUtils.ts
@@ -167,6 +167,7 @@ export function lambdaAPIGatewayContext(
         // See  https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
         return {
             statusCode,
+            headers: {"Access-Control-Allow-Origin": "*"},
             body
         };
     };

--- a/packages/stentor/src/__test__/Assistant.test.ts
+++ b/packages/stentor/src/__test__/Assistant.test.ts
@@ -166,6 +166,7 @@ describe("Assistant", () => {
                 expect(callback).to.have.been.calledOnce;
                 expect(callback).to.have.been.calledWith(null, {
                     statusCode: 500,
+                    headers: { "Access-Control-Allow-Origin": "*" },
                     body:
                         "Error: Runtime Error"
                 });


### PR DESCRIPTION
Very simple fix. It's needed for the widget to connect from browsers. "cors: true" in the serverless yml is not enough.