### PR TITLE
fix: Slot Conditional Checks had conditional check for adding them

### DIFF
--- a/packages/stentor-determiner/src/determine.ts
+++ b/packages/stentor-determiner/src/determine.ts
@@ -24,8 +24,7 @@ import {
     isRequestDependable,
     isSystemDependable,
     SystemConditionalCheck,
-    RequestConditionalCheck,
-    hasSlots
+    RequestConditionalCheck
 } from "stentor-request";
 import { findStorageDependentMatch, isStorageDependable } from "stentor-storage";
 import { findTimeContextualMatch, TimeConditionalCheck } from "stentor-time";
@@ -111,18 +110,13 @@ export function determine<P extends object>(potentials: P[], request: Request, c
         const checks: ConditionalCheck[] = [
             JSONConditionalCheck(request, context),
             SystemConditionalCheck(request, context),
-            RequestConditionalCheck(request)
+            RequestConditionalCheck(request),
+            SlotConditionalCheck(request)
         ];
         // If we have a lastActiveTimestamp, which we most always do 
         if (context && context.storage && typeof context.storage.lastActiveTimestamp === "number") {
             const lastActiveTimestamp = context.storage.lastActiveTimestamp;
             checks.push(TimeConditionalCheck({ lastActiveTimestamp }));
-        }
-
-        // If we have slots
-        if (hasSlots(request) && isIntentRequest(request)) {
-            const slots = request.slots;
-            checks.push(SlotConditionalCheck(slots));
         }
 
         // Big show, determine the matches

--- a/packages/stentor-interaction-model/src/__test__/SlotConditionalCheck.test.ts
+++ b/packages/stentor-interaction-model/src/__test__/SlotConditionalCheck.test.ts
@@ -1,9 +1,8 @@
 /*! Copyright (c) 2020, XAPPmedia */
 import { expect } from "chai";
 
-import { SlotDependent, RequestSlotMap } from "stentor-models";
-import { SlotConditionalCheck } from "../SlotConditionalCheck";
-
+import { IntentRequest, SlotDependent, RequestSlotMap } from "stentor-models";
+import { hasSlot, SlotConditionalCheck, slotDoesNotExist, slotExists, slotEquals } from "../SlotConditionalCheck";
 
 const obj: SlotDependent = {
     slotMatch: {
@@ -22,6 +21,50 @@ const slotsWithFooAsBar: RequestSlotMap = {
         value: ""
     }
 };
+
+const request: IntentRequest = {
+    intentId: "intentId",
+    type: "INTENT_REQUEST",
+    slots: slotsWithFooAsBar,
+    sessionId: "sessionId",
+    userId: "userId"
+}
+
+describe(`#${hasSlot.name}()`, () => {
+    it('returns the correct result', () => {
+        expect(hasSlot(undefined, "foo")).to.be.false;
+        expect(hasSlot(slotsWithFooAsBar, "baz")).to.be.false;
+        expect(hasSlot(slotsWithFooAsBar, "foo")).to.be.true;
+        expect(hasSlot(slotsWithFooAsBar, "bar")).to.be.false;
+    });
+});
+
+describe(`#${slotExists.name}()`, () => {
+    it('returns the correct result', () => {
+        expect(slotExists(undefined, "foo")).to.be.false;
+        expect(slotExists(slotsWithFooAsBar, "baz")).to.be.false;
+        expect(slotExists(slotsWithFooAsBar, "foo")).to.be.true;
+        expect(slotExists(slotsWithFooAsBar, "bar")).to.be.false;
+    });
+});
+
+describe(`#${slotDoesNotExist.name}()`, () => {
+    it('returns the correct result', () => {
+        expect(slotDoesNotExist(undefined, "foo")).to.be.true;
+        expect(slotDoesNotExist(slotsWithFooAsBar, "baz")).to.be.true;
+        expect(slotDoesNotExist(slotsWithFooAsBar, "foo")).to.be.false;
+        expect(slotDoesNotExist(slotsWithFooAsBar, "bar")).to.be.true;
+    });
+});
+
+describe(`#${slotEquals.name}()`, () => {
+    it('returns the correct result', () => {
+        expect(slotEquals(undefined, "foo", "bar")).to.be.false;
+        expect(slotEquals(slotsWithFooAsBar, "baz", "bar")).to.be.false;
+        expect(slotEquals(slotsWithFooAsBar, "foo", "bar")).to.be.true;
+        expect(slotEquals(slotsWithFooAsBar, "bar", "foo")).to.be.false;
+    });
+});
 
 describe(`${SlotConditionalCheck.name}`, () => {
     describe(`test`, () => {
@@ -56,6 +99,14 @@ describe(`${SlotConditionalCheck.name}`, () => {
             const slotExists = SlotConditionalCheck(slotsWithFooAsBar).functions[3];
             expect(slotExists("foo")).to.be.true;
 
+        });
+    });
+    describe('when passed a request', () => {
+        it('returns the correct result', () => {
+            const hasSlot = SlotConditionalCheck(request).functions[0];
+            expect(hasSlot("foo")).to.be.true;
+            expect(hasSlot("bar")).to.be.false;
+            expect(hasSlot("baz")).to.be.false;
         });
     });
 });


### PR DESCRIPTION
A little silly this was in place after discovering this issue but we only added the slot based conditional checks if the intent request had slots.  This then caused a problem for the conditional check `slotExists` because that conditional check wouldn't exist and throw an error.