### PR TITLE
fix: Crash with handler.data is undefined

### DIFF
--- a/packages/stentor-handler/src/AbstractHandler/Handler.ts
+++ b/packages/stentor-handler/src/AbstractHandler/Handler.ts
@@ -199,7 +199,7 @@ export abstract class AbstractHandler<
      * @memberof Handler
      */
     protected async inputUnknown(request: Request, context: Context): Promise<void> {
-        switch (this.data.inputUnknownStrategy) {
+        switch (this.data?.inputUnknownStrategy) {
             case INPUT_UNKNOWN_STRATEGY_REPROMPT:
                 if (context.storage.previousResponse && context.storage.previousResponse.reprompt) {
                     const reprompt = context.storage.previousResponse.reprompt;

--- a/packages/stentor-handler/src/AbstractHandler/__test__/Handler.test.ts
+++ b/packages/stentor-handler/src/AbstractHandler/__test__/Handler.test.ts
@@ -22,7 +22,6 @@ import {
     InputUnknownRequestBuilder,
     INTENT_REQUEST_TYPE,
     IntentRequestBuilder,
-
     OptionSelectBuilder
 } from "stentor-request";
 import { ResponseBuilder } from "stentor-response";
@@ -459,6 +458,24 @@ describe("AbstractHandler", () => {
                 expect(response.say).to.have.been.calledWith(previousResponse.reprompt);
                 expect(response.reprompt).to.have.been.called;
                 expect(response.reprompt).to.have.been.calledWith(previousResponse.reprompt);
+            });
+        });
+        describe("with undefined data", () => {
+            beforeEach(() => {
+                newContext = new ContextBuilder().withResponse(response).build();
+                handler = new TestHandler({
+                    appId,
+                    organizationId,
+                    intentId,
+                    type: BASE_HANDLER_TYPE,
+                    content
+                });
+                request = new InputUnknownRequestBuilder().build();
+            });
+            it("returns the first time response", async () => {
+                await handler.handleRequest(request, newContext);
+                expect(response.say).to.have.been.called;
+                expect(response.say).to.have.been.calledWith("Sorry, what was that?");
             });
         });
     });


### PR DESCRIPTION
When an InputUnknown happens and the data field is undefined, the handler could crash.