### PR TITLE
fix: Convert \n to <br /> tags in markdown

### DIFF
--- a/packages/stentor-channel/src/__tests__/TranslateToStentorResponse.test.ts
+++ b/packages/stentor-channel/src/__tests__/TranslateToStentorResponse.test.ts
@@ -46,7 +46,7 @@ describe(`${TranslateStentorResponse.name}`, () => {
                     if (typeof response.outputSpeech === "object") {
                         expect(response.outputSpeech.displayText).to.equal(displayText);
                         expect(response.outputSpeech.html).to.exist;
-                        expect(response.outputSpeech.html).to.equal("<p><strong>Hi</strong>\n    How are you? <em>Bye</em></p>\n");
+                        expect(response.outputSpeech.html).to.equal("<p><strong>Hi</strong><br />    How are you? <em>Bye</em></p>\n");
                     }
                     expect(response.reprompt).to.be.an("object");
                     if (typeof response.reprompt === "object") {

--- a/packages/stentor-utils/src/__test__/markdown.test.ts
+++ b/packages/stentor-utils/src/__test__/markdown.test.ts
@@ -10,11 +10,15 @@ describe(`#${toHTML.name}()`, () => {
     });
     describe("when passed markdown", () => {
         it("returns the correct result", () => {
+            expect(toHTML("one  \ntwo")).to.equal("<p>one<br />two</p>\n");
+            expect(toHTML("one\  \ntwo")).to.equal("<p>one<br />two</p>\n");
+            expect(toHTML("**Simulated List**\n\n- one\n- two\n- three")).to.equal("<p><strong>Simulated List</strong></p>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n");
+            expect(toHTML("one\ntwo\nthree")).to.equal("<p>one<br />two<br />three</p>\n");
             expect(toHTML("**Bold**")).to.equal("<p><strong>Bold</strong></p>\n");
             expect(toHTML("_Italic_")).to.equal("<p><em>Italic</em></p>\n");
             expect(toHTML("_Italic_ **Bold** [Google](https://google.com)")).to.equal("<p><em>Italic</em> <strong>Bold</strong> <a target=\"_blank\" href=\"https://google.com\">Google</a></p>\n");
             expect(toHTML("_Italic_ **Bold** [Google](https://google.com)")).to.equal("<p><em>Italic</em> <strong>Bold</strong> <a target=\"_blank\" href=\"https://google.com\">Google</a></p>\n");
-            expect(toHTML("_Italic_\n**Bold**\n[Google](https://google.com)")).to.equal("<p><em>Italic</em>\n<strong>Bold</strong>\n<a target=\"_blank\" href=\"https://google.com\">Google</a></p>\n");
+            expect(toHTML("_Italic_\n**Bold**\n[Google](https://google.com)")).to.equal("<p><em>Italic</em><br /><strong>Bold</strong><br /><a target=\"_blank\" href=\"https://google.com\">Google</a></p>\n");
             expect(toHTML("_Italic_\t")).to.equal("<p><em>Italic</em>    </p>\n");
             expect(toHTML("_Italic_ <a href=&quot;http://www.google.com&quot;>Google</a>")).to.equal("<p><em>Italic</em> <a href=\"http://www.google.com\">Google</a></p>\n");
             expect(toHTML("**Bold** www.xapp.ai _Italic_")).to.equal("<p><strong>Bold</strong> <a target=\"_blank\" href=\"https://www.xapp.ai\">www.xapp.ai</a> <em>Italic</em></p>\n");

--- a/packages/stentor-utils/src/markdown.ts
+++ b/packages/stentor-utils/src/markdown.ts
@@ -31,11 +31,10 @@ export function toHTML(input: string): string {
     const linkRenderer = renderer.link;
     renderer.link = (href, title, text): string => {
         const html = linkRenderer.call(renderer, href, title, text);
-        return html.replace(/^<a /, '<a target="_blank" rel="nofollow" ');
+        return html.replace(/^<a /, `<a target="_blank" rel="nofollow" `);
     };
-    const dirty = marked(linked, { renderer });
+    const dirty = marked(linked, { renderer, breaks: true, xhtml: true });
 
     const clean = sanitize(dirty);
-
     return clean;
 }


### PR DESCRIPTION
`\n` is not displayed within HTML however `<br />` achieves what we want.