### PR TITLE
chore: Add device to request and deprecate it on context

### DIFF
--- a/packages/stentor-context/src/ContextBuilder.ts
+++ b/packages/stentor-context/src/ContextBuilder.ts
@@ -48,6 +48,12 @@ export class ContextBuilder<S extends Storage = Storage> extends AbstractBuilder
         };
     }
 
+    /**
+     * 
+     * @deprecated - Device will be removed from the context in the next major release.  Use device on request.
+     * @param device 
+     * @returns 
+     */
     public withDevice(device: Device): ContextBuilder<S> {
         this.context.device = device;
         return this;

--- a/packages/stentor-context/src/ContextFactory.ts
+++ b/packages/stentor-context/src/ContextFactory.ts
@@ -27,6 +27,13 @@ export interface ContextFactoryServices {
 export class ContextFactory {
     /**
      * Build context from the provided request.
+     *
+     * @param request 
+     * @param requestBody 
+     * @param services 
+     * @param channel - This field will disappear in the next major release.  It is only used to set the device field on the context.
+     * @param appData 
+     * @returns 
      */
     public static async fromRequest(
         request: Request,

--- a/packages/stentor-models/src/Context.ts
+++ b/packages/stentor-models/src/Context.ts
@@ -28,6 +28,8 @@ export type UserData = (userDataType: UserDataType) => Promise<UserDataRequestSt
 export interface Context<S extends Storage = Storage> {
     /**
      * Information about the current device the user is on within the channel.
+     * 
+     * @deprecated - Will be removed in next major release.  You can find the same information on the request.
      */
     device: Device;
     /**

--- a/packages/stentor-models/src/Request/IntentRequest.ts
+++ b/packages/stentor-models/src/Request/IntentRequest.ts
@@ -7,7 +7,6 @@ import { KnowledgeAnswer, KnowledgeBaseResult } from "./KnowledgeBase";
 
 export type RequestSlotValues = string | number | object | DateTimeRange | DateTime | Duration | (string)[];
 
-
 export interface RequestAttachment {
     /**
      * Url to the uploaded file

--- a/packages/stentor-models/src/Request/Request.ts
+++ b/packages/stentor-models/src/Request/Request.ts
@@ -1,4 +1,5 @@
 /*! Copyright (c) 2019, XAPPmedia */
+import { Device } from "../Device";
 import { Locale } from "../Locale";
 import { AudioPlayerRequest } from "./AudioPlayerRequest";
 import { InputUnknownRequest } from "./InputUnknownRequest";
@@ -70,6 +71,10 @@ export interface BaseRequest {
      * The specific channel that the platform provides.  
      */
     channel?: string;
+    /**
+     * Information about the device as far as capabilities such as screen or web browser available.
+     */
+    device?: Device;
     /**
      * User's locale, such as us-EN and es-MX.
      *

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,10 +1995,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@2.918.0:
-  version "2.918.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.918.0.tgz#e4323de000262beb762e9c139f89e07282462f17"
-  integrity sha512-ZjWanOA1Zo664EyWLCnbUlkwCjoRPmSIMx529W4gk1418qo3oCEcvUy1HeibGGIClYnZZ7J4FMQvVDm2+JtHLQ==
+aws-sdk@2.923.0:
+  version "2.923.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.923.0.tgz#97a95686e9dba10f628092bfd90f84397c8ad55f"
+  integrity sha512-93YK9Mx32qvH5eLrDRVkvwpEc7GJ6mces1qQugmNZCuQT68baILyDs0IMRtHS6NYxxiM6XNRFc7ubgMlnafYjg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
Currently, device information such as has a web browser or screen output is on the application context object.  Moving this to the request has a couple of benefits:

1. Include all the necessary information about the users context on the request for more helpful downstream processing (analytics & insights).
2. Clean up the need to pass the channel information to the application context builder just for the purposes of adding the device info to the app context.
3. Use this device information when translating the response and give appropriate warnings & errors.  It is important to know if the device has a screen when you are about to translate information such as lists.  This is currently not available.