### PR TITLE
feat: Support for Input Contexts

### DIFF
--- a/packages/stentor-models/src/Intent/Intent.ts
+++ b/packages/stentor-models/src/Intent/Intent.ts
@@ -108,6 +108,19 @@ export interface Intent extends Localizable<LocaleSpecificIntent> {
      */
     defaultLocale?: Locale;
     /**
+     * Contexts the must be active to have this intent be weighted more heavily or selected.
+     * 
+     * For Amazon Lex, the contexts are required to be selected.  
+     * 
+     * {@link https://docs.aws.amazon.com/lex/latest/dg/API_PutIntent.html#lex-PutIntent-request-inputContexts}
+     * 
+     * For Dialogflow ES, these are more heavily weighted towards matching.
+     * 
+     * {@link https://cloud.google.com/dialogflow/es/docs/contexts-input-output#input_contexts}
+     * {@link https://cloud.google.com/dialogflow/es/docs/reference/rest/v2/projects.agent.intents#Intent}
+     */
+    contexts?: { name: string }[];
+    /**
      * NLU specific metadata used when translating the intentId to a NLU specific type.
      * 
      * Use to override the type for a specific NLU. 

--- a/packages/stentor-models/src/Response/Response.ts
+++ b/packages/stentor-models/src/Response/Response.ts
@@ -13,6 +13,31 @@ import { ResponseOutput } from "./ResponseOutput";
 import { ResponseSegmentsMap } from "./ResponseSegment";
 
 /**
+ * Active Context Object
+ * 
+ */
+export interface ActiveContext {
+    /**
+     * Name of the context
+     */
+    name: string;
+    /**
+     * Parameters passed around with the context
+     */
+    parameters?: {
+        [key: string]: string;
+    }
+    timeToLive: {
+        /**
+         * Not supported on Dialogflow
+         */
+        timeToLiveInSeconds?: number;
+        turnsToLive?: number;
+    }
+}
+
+
+/**
  * Additional response metadata.
  */
 export interface ResponseData {
@@ -104,6 +129,19 @@ export interface SimpleResponse<T = string | ResponseOutput> extends Partial<Act
      * Supplemental data to augment the response.
      */
     data?: ResponseData;
+    /**
+     * Optional active contexts which help influence the NLU.
+     * 
+     * - {@link https://cloud.google.com/dialogflow/es/docs/contexts-input-output}
+     * - {@link https://docs.aws.amazon.com/lex/latest/dg/context-mgmt-active-context.html}
+     */
+    context?: {
+        /**
+         * 
+         * Matches to outputContexts on Dialogflow & activeContexts
+         */
+        active?: ActiveContext[];
+    };
 }
 /**
  * A response that can be scheduled.

--- a/packages/stentor-response/src/ResponseBuilder.ts
+++ b/packages/stentor-response/src/ResponseBuilder.ts
@@ -132,13 +132,7 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
             return this;
         }
 
-        let active: ActiveContext[] = this._response?.context?.active || [];
-
-        if (Array.isArray(context)) {
-            active = active.concat(context);
-        } else {
-            active.push(context);
-        }
+        const active: ActiveContext[] = (this._response?.context?.active || []).concat(context);
 
         this._response.context = {
             ...this._response.context,

--- a/packages/stentor-response/src/ResponseBuilder.ts
+++ b/packages/stentor-response/src/ResponseBuilder.ts
@@ -48,10 +48,10 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
     }
 
     /**
+     * Communicate to the provided text user.  Depending on the channel, this will be displayed in a chat message style bubble
+     * or spoken with text to speech.  You can provide both at the same time, text for display (displayText) or spoken (ssml).
      * 
-     * @param say 
-     * @param append 
-     * @returns 
+     * If you use this without also providing a reprompt, the conversation will end on channels with voice input.
      */
     public say(say: string | ResponseOutput, append?: boolean): ResponseBuilder<T> {
         if (!say) {
@@ -68,6 +68,9 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
         return this;
     }
 
+    /**
+     * Used on voice input channels, the reprompt is used when the user does not provide an input within a timely manner.
+     */
     public reprompt(reprompt: string | ResponseOutput, append?: boolean): ResponseBuilder<T> {
         if (!this._response.outputSpeech) {
             throw new Error("Cannot call #reprompt() without first calling #say()");

--- a/packages/stentor-response/src/ResponseBuilder.ts
+++ b/packages/stentor-response/src/ResponseBuilder.ts
@@ -2,6 +2,7 @@
 import { Playlist } from "stentor-media";
 import {
     AbstractResponseBuilder,
+    ActiveContext,
     CanFulfillIntentResult,
     Card,
     ListItem,
@@ -24,7 +25,11 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
     public constructor(props: ResponseBuilderProps) {
         super(props);
     }
-
+    /**
+     * Provide a fully formed response object
+     * 
+     * Note: This will overwrite any existing response that has been set previously with the builder.
+     */
     public respond(response: Response): ResponseBuilder<T> {
         if (!response) {
             return this;
@@ -42,6 +47,12 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
         return this;
     }
 
+    /**
+     * 
+     * @param say 
+     * @param append 
+     * @returns 
+     */
     public say(say: string | ResponseOutput, append?: boolean): ResponseBuilder<T> {
         if (!say) {
             return this;
@@ -78,6 +89,9 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
         return this;
     }
 
+    /**
+     * Provide suggestion chips to the response.
+     */
     public withSuggestions(suggestion: SuggestionTypes | SuggestionTypes[], append?: boolean): ResponseBuilder<T> {
         if (!this._response.outputSpeech) {
             throw new Error("Cannot call #withSuggestions() without first calling #say()");
@@ -106,10 +120,38 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
         return this;
     }
 
+    /**
+     * Provides active context that the NLU can use to help select the next intent.
+     */
+    public withActiveContext(context: ActiveContext | ActiveContext[]): ResponseBuilder<T> {
+
+        if (!context) {
+            return this;
+        }
+
+        let active: ActiveContext[] = this._response?.context?.active || [];
+
+        if (Array.isArray(context)) {
+            active = active.concat(context);
+        } else {
+            active.push(context);
+        }
+
+        this._response.context = {
+            ...this._response.context,
+            active
+        }
+
+        return this;
+    }
+
     /*
      * Display
      */
 
+    /**
+     * Add a display card element to the response.
+     */
     public withCard(card: Card): ResponseBuilder<T> {
         if (!card) {
             return this;
@@ -122,6 +164,9 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
         return this;
     }
 
+    /**
+     * Add a vertical list to the response
+     */
     public withList(items: ListItem[], title?: string): ResponseBuilder<T> {
         if (Array.isArray(items)) {
             if (!Array.isArray(this._response.displays)) {
@@ -137,6 +182,9 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
         return this;
     }
 
+    /**
+     * Add a horizontal list to the response.
+     */
     public withCarousel(items: ListItem[]): ResponseBuilder<T> {
         if (Array.isArray(items)) {
             if (!Array.isArray(this._response.displays)) {
@@ -236,6 +284,10 @@ export class ResponseBuilder<T = Response<ResponseOutput>> extends AbstractRespo
 
     /*
      * Media
+     */
+
+    /**
+     * Play the provided media.
      */
     public play(playable: PlayableMedia): ResponseBuilder<T> {
         if (!playable) {

--- a/packages/stentor-response/src/__test__/ResponseBuilder.test.ts
+++ b/packages/stentor-response/src/__test__/ResponseBuilder.test.ts
@@ -394,7 +394,7 @@ describe("ResponseBuilder", () => {
             });
         });
     });
-    describe.only(`#${ResponseBuilder.prototype.withActiveContext.name}()`, () => {
+    describe(`#${ResponseBuilder.prototype.withActiveContext.name}()`, () => {
         describe("when passed a single context", () => {
             it("sets the active contexts", () => {
                 const response = new ResponseBuilder({ device })

--- a/packages/stentor-response/src/__test__/ResponseBuilder.test.ts
+++ b/packages/stentor-response/src/__test__/ResponseBuilder.test.ts
@@ -394,6 +394,58 @@ describe("ResponseBuilder", () => {
             });
         });
     });
+    describe.only(`#${ResponseBuilder.prototype.withActiveContext.name}()`, () => {
+        describe("when passed a single context", () => {
+            it("sets the active contexts", () => {
+                const response = new ResponseBuilder({ device })
+                    .say("foo")
+                    .withActiveContext({ name: "bar", timeToLive: { turnsToLive: 2 } })
+                    .build();
+
+                expect(response).to.exist;
+                expect(response.context).to.deep.equal({
+                    active: [{ name: "bar", timeToLive: { turnsToLive: 2 } }]
+                });
+            });
+        });
+        describe("when passed an array of contexts", () => {
+            it("sets the active contexts", () => {
+                const response = new ResponseBuilder({ device })
+                    .say("foo")
+                    .withActiveContext([{ name: "bar", timeToLive: { turnsToLive: 2 } }])
+                    .build();
+
+                expect(response).to.exist;
+                expect(response.context).to.deep.equal({
+                    active: [{ name: "bar", timeToLive: { turnsToLive: 2 } }]
+                });
+            });
+        });
+        describe("when called more than once", () => {
+            it("adds all the contexts", () => {
+                const response = new ResponseBuilder({ device })
+                    .say("foo")
+                    .withActiveContext({ name: "bar", timeToLive: { turnsToLive: 2 } })
+                    .withActiveContext([{ name: "baz", timeToLive: { turnsToLive: 4 } }])
+                    .build();
+
+                expect(response).to.exist;
+                expect(response.context).to.deep.equal({
+                    active: [
+                        { name: "bar", timeToLive: { turnsToLive: 2 } },
+                        { name: "baz", timeToLive: { turnsToLive: 4 } }
+                    ]
+                });
+            });
+        });
+        describe("when passed undefined", () => {
+            it("does nothing", () => {
+                const response = new ResponseBuilder({ device }).say("foo").withActiveContext(undefined).build();
+                expect(response).to.exist;
+                expect(response.context).to.be.undefined;
+            });
+        });
+    });
     describe("#withCard()", () => {
         describe("when passed undefined", () => {
             it("it doesn't set displays", () => {


### PR DESCRIPTION
Input contexts are supported by both Amazon Lex & Dialogflow, they allow you to provide additional information to help the NLU pick the intent from the user's query.  They can be extremely helpful when you have multiple potential high confidence intent matches within the NLU for a particular query.  

