### PR TITLE
fix: Ability to now compile boolean false values in responses

### DIFF
--- a/packages/stentor-response/src/__test__/compileResponse.test.ts
+++ b/packages/stentor-response/src/__test__/compileResponse.test.ts
@@ -699,7 +699,7 @@ describe(`#${compileResponse.name}()`, () => {
 
                 compiledResponse = compileResponse(displayResponse, request, context);
             });
-            it.only("compiles the displays", () => {
+            it("compiles the displays", () => {
                 expect(compileResponse).to.exist;
                 expect(compiledResponse.displays).to.have.length(1);
                 const display = compiledResponse.displays[0];

--- a/packages/stentor-response/src/__test__/compileResponse.test.ts
+++ b/packages/stentor-response/src/__test__/compileResponse.test.ts
@@ -699,7 +699,7 @@ describe(`#${compileResponse.name}()`, () => {
 
                 compiledResponse = compileResponse(displayResponse, request, context);
             });
-            it("compiles the displays", () => {
+            it.only("compiles the displays", () => {
                 expect(compileResponse).to.exist;
                 expect(compiledResponse.displays).to.have.length(1);
                 const display = compiledResponse.displays[0];

--- a/packages/stentor-response/src/compileResponse.ts
+++ b/packages/stentor-response/src/compileResponse.ts
@@ -2,6 +2,7 @@
 import { TEMPLATE_REGEX } from "stentor-constants";
 import { isTemplatedList } from "stentor-guards";
 import { localize } from "stentor-locales";
+import { log } from "stentor-logger";
 import { Context, Request, Response } from "stentor-models";
 import { Compiler, DEFAULT_MARCOS, existsAndNotEmpty, getJSONPath, MacroMap } from "stentor-utils";
 
@@ -87,6 +88,9 @@ export function compileResponse(
             const itemsName = firstDisplay.itemsName || "items";
             // The collection variable. The regex is just for the syntactical similarity. ex  "${ $.session.storeList }"
             const itemsObject = firstDisplay.itemsObject;
+            // then delete these since they may cause problems later in compilation
+            delete firstDisplay.itemsObject;
+            delete firstDisplay.itemsName;
 
             // If dynamic no reason to give more
             if (firstDisplay.items.length !== 1) {
@@ -158,7 +162,7 @@ export function compileResponse(
                     // Only update if it doesn't explode
                     compiledItems.push(compiledItem);
                 } catch (e) {
-                    console.info("Could not parse compiled displays");
+                    log().error(`Could not compile display:`, e);
                 }
 
                 // ok, time to update the items.
@@ -179,7 +183,7 @@ export function compileResponse(
             // Only update if it doesn't explode
             compiledResponse.displays = compiledDisplays;
         } catch (e) {
-            console.info("Could not parse compiled displays");
+            log().error(`Could not compile display:`, e);
         }
     }
 


### PR DESCRIPTION
Boolean `false` values from JSON Path evaluation turned out to fail the check if results returned or not and then were not compiled. 