### PR TITLE
fix: Update preciseLocation to use coordinates isntead of string.

### DIFF
--- a/packages/stentor-models/src/Pii.ts
+++ b/packages/stentor-models/src/Pii.ts
@@ -19,7 +19,12 @@ export interface Pii {
     customDataStatus?: OptStatus;
 
     name?: string;
-    preciseLocation?: string;
+    preciseLocation?: {
+        coordinates?: {
+            latitude: number;
+            longitude: number;
+        };
+    };
     coarseLocation?: string;
 
     pendingSmsJobs?: SmsDescription[];

--- a/packages/stentor-models/src/UserProfile.ts
+++ b/packages/stentor-models/src/UserProfile.ts
@@ -17,7 +17,12 @@ export interface UserProfile {
     // NONE OF THEM PROVIDES it YET
     phone?: string;
     // NOT USED YET
-    preciseLocation?: string;
+    preciseLocation?: {
+        coordinates?: {
+            latitude: number;
+            longitude: number;
+        }
+    };
     // NOT USED YET
     coarseLocation?: string;
 }


### PR DESCRIPTION
This updates `preciseLocation` on the User Data & PII to use an object consisting of latitude and longitude coordinates.