### PR TITLE
BREAKING CHANGE: Modifies forwardingPathForRequest and redirectingPathForRequest to be async

### DIFF
--- a/packages/stentor-handler-manager/src/HandlerManager.ts
+++ b/packages/stentor-handler-manager/src/HandlerManager.ts
@@ -63,8 +63,7 @@ export class HandlerManager {
         const handlerFromStorage: AbstractHandler = this.factory.from(request, context);
         if (isHandler(handlerFromStorage) && handlerFromStorage.canHandleRequest(request, context)) {
             log().info(
-                `Using handler from storage with id: ${handlerFromStorage.intentId} which can handle the request ${
-                request.type
+                `Using handler from storage with id: ${handlerFromStorage.intentId} which can handle the request ${request.type
                 }-${keyFromRequest(request)}`
             );
             handler = handlerFromStorage;
@@ -72,8 +71,7 @@ export class HandlerManager {
         // STEP #0.1 Another check, see if it is an InputUnknown request and it can handle it
         if (isHandler(handlerFromStorage) && isInputUnknownRequest(request) && handlerFromStorage.canHandleInputUnknown(request, context)) {
             log().info(
-                `Using handler from storage with id: ${handlerFromStorage.intentId} which can handle the request ${
-                request.type
+                `Using handler from storage with id: ${handlerFromStorage.intentId} which can handle the request ${request.type
                 }-${keyFromRequest(request)}`
             );
             handler = handlerFromStorage;
@@ -86,7 +84,7 @@ export class HandlerManager {
         // NOTE: if a path is found, it sets requestHandler = undefined;
         if (handler) {
             if (isHandler(handler)) {
-                const path = handler.forwardingPathForRequest(request, context);
+                const path = await handler.forwardingPathForRequest(request, context);
                 // if we do have a path
                 if (path) {
                     // make a new
@@ -190,7 +188,7 @@ export class HandlerManager {
         // See if we have a redirecting path for the request
         if (handler) {
             if (isHandler(handler)) {
-                const path = handler.redirectingPathForRequest(request, context);
+                const path = await handler.redirectingPathForRequest(request, context);
                 // if we do have a path
                 if (path) {
                     // make a new

--- a/packages/stentor-handler/src/AbstractHandler/Handler.ts
+++ b/packages/stentor-handler/src/AbstractHandler/Handler.ts
@@ -123,7 +123,8 @@ export abstract class AbstractHandler<
      *
      * @public
      */
-    public forwardingPathForRequest(request: Request, context: Context): ExecutablePath | undefined {
+
+    public async forwardingPathForRequest(request: Request, context: Context): Promise<ExecutablePath> | undefined {
         const key = keyFromRequest(request);
         const paths = findValueForKey(key, this.forward);
         return determinePath(paths, request, context);
@@ -136,7 +137,7 @@ export abstract class AbstractHandler<
      *
      * @public
      */
-    public redirectingPathForRequest(request: Request, context: Context): ExecutablePath | undefined {
+    public async redirectingPathForRequest(request: Request, context: Context): Promise<ExecutablePath> | undefined {
         const key = keyFromRequest(request);
         const paths = findValueForKey(key, this.redirect);
         return determinePath(paths, request, context);

--- a/packages/stentor-handler/src/AbstractHandler/__test__/Handler.test.ts
+++ b/packages/stentor-handler/src/AbstractHandler/__test__/Handler.test.ts
@@ -866,7 +866,7 @@ describe("AbstractHandler", () => {
             });
         });
         describe("without forward set", () => {
-            it("returns undefined", () => {
+            it("returns undefined", async () => {
                 const request = {
                     ...intentRequest,
                     intentId: "someRandomIntent"
@@ -878,7 +878,8 @@ describe("AbstractHandler", () => {
                         ...storageProps
                     })
                     .build();
-                expect(handler.forwardingPathForRequest(request, context)).to.be.undefined;
+                const path = await handler.forwardingPathForRequest(request, context)
+                expect(path).to.be.undefined;
             });
         });
         describe("with forwards", () => {
@@ -897,7 +898,7 @@ describe("AbstractHandler", () => {
                     }
                 });
             });
-            it("matches to the correct one on an exact match", () => {
+            it("matches to the correct one on an exact match", async () => {
                 const request = {
                     ...intentRequest,
                     intentId: STOP_INTENT
@@ -909,10 +910,11 @@ describe("AbstractHandler", () => {
                         ...storageProps
                     })
                     .build();
-                expect(handler.forwardingPathForRequest(request, context)).to.exist;
-                expect(handler.forwardingPathForRequest(request, context).intentId).to.equal("ForwardedStop");
+                const path = await handler.forwardingPathForRequest(request, context)
+                expect(path).to.exist;
+                expect(path.intentId).to.equal("ForwardedStop");
             });
-            it("matches to the fallback regex", () => {
+            it("matches to the fallback regex", async () => {
                 const request = {
                     ...intentRequest,
                     intentId: "random"
@@ -924,10 +926,11 @@ describe("AbstractHandler", () => {
                         ...storageProps
                     })
                     .build();
-                expect(handler.forwardingPathForRequest(request, context)).to.exist;
-                expect(handler.forwardingPathForRequest(request, context).intentId).to.equal("Fallback");
+                const path = await handler.forwardingPathForRequest(request, context);
+                expect(path).to.exist;
+                expect(path.intentId).to.equal("Fallback");
             });
-            it("returns undefined for unmatched", () => {
+            it("returns undefined for unmatched", async () => {
                 const request = {
                     ...intentRequest,
                     intentId: HELP_INTENT
@@ -939,7 +942,8 @@ describe("AbstractHandler", () => {
                         ...storageProps
                     })
                     .build();
-                expect(handler.forwardingPathForRequest(request, context)).to.be.undefined;
+                const path = await handler.forwardingPathForRequest(request, context)
+                expect(path).to.be.undefined;
             });
         });
     });

--- a/packages/stentor-models/src/Context.ts
+++ b/packages/stentor-models/src/Context.ts
@@ -5,7 +5,7 @@ import { AbstractResponseBuilder } from "./Response";
 import { SessionStore, Storage } from "./Storage";
 import { UserDataType } from "./UserData";
 import { UserProfile } from "./UserProfile";
-import { CrmService, KnowledgeBaseService, SMSService } from "./Services";
+import { CrmService, SMSService } from "./Services";
 
 export enum UserDataRequestStatus {
     DEFERRED,
@@ -33,10 +33,6 @@ export interface ContextServices {
      * Service for sending text messages
      */
     smsService?: SMSService;
-    /**
-     * Service for calling a knowledgebase.
-     */
-    knowledgeBaseService?: KnowledgeBaseService;
 }
 
 /**

--- a/packages/stentor-models/src/Context.ts
+++ b/packages/stentor-models/src/Context.ts
@@ -5,7 +5,7 @@ import { AbstractResponseBuilder } from "./Response";
 import { SessionStore, Storage } from "./Storage";
 import { UserDataType } from "./UserData";
 import { UserProfile } from "./UserProfile";
-import { CrmService, SMSService } from "./Services";
+import { CrmService, KnowledgeBaseService, SMSService } from "./Services";
 
 export enum UserDataRequestStatus {
     DEFERRED,
@@ -25,8 +25,18 @@ export type UserData = (userDataType: UserDataType) => Promise<UserDataRequestSt
  * These we want to make available for custom handlers
  */
 export interface ContextServices {
+    /**
+     * Service for sending information to a CRM
+     */
     crmService?: CrmService;
+    /**
+     * Service for sending text messages
+     */
     smsService?: SMSService;
+    /**
+     * Service for calling a knowledgebase.
+     */
+    knowledgeBaseService?: KnowledgeBaseService;
 }
 
 /**


### PR DESCRIPTION
Small breaking change, modifies two methods on the AbstractHandler to be async.

These two functions are exposed in the public API but are not typically used and the migration is straight forward (just add an async).  I would not recommend a major version bump for this change.