### PR TITLE
fix: Add request attributes and update CRM Transcript

### DIFF
--- a/packages/stentor-models/src/Crm.ts
+++ b/packages/stentor-models/src/Crm.ts
@@ -6,10 +6,6 @@ export interface LeadFormField {
     value: string;
 }
 
-export interface CrmTranscriptAttributes {
-    [attribute: string]: unknown;
-}
-
 export interface ExternalLead {
     fields: LeadFormField[];
     source?: string;

--- a/packages/stentor-models/src/Crm.ts
+++ b/packages/stentor-models/src/Crm.ts
@@ -1,4 +1,5 @@
 /*! Copyright (c) 2022, XAPPmedia */
+import { Message } from "./Message";
 
 export interface LeadFormField {
     name: string;
@@ -9,26 +10,11 @@ export interface CrmTranscriptAttributes {
     [attribute: string]: unknown;
 }
 
-/**
- * Transcript representation of the session. The input/output is an easily readable, simplified representation
- * of the visitor/bot "chat". This is usually emailed or sent to a CRM system or customer service for a quick overview.
- * That is why input an output are strings.
- */
-export interface CrmTranscriptExchange {
-    input: string;
-    output: string;
-    attributes?: CrmTranscriptAttributes;
-}
-
-export interface CrmTranscript {
-    items: CrmTranscriptExchange[];
-}
-
 export interface ExternalLead {
     fields: LeadFormField[];
     source?: string;
     company?: string;
-    transcript?: CrmTranscript[];
+    transcript?: Message[];
 }
 
 export interface CrmResponse {

--- a/packages/stentor-models/src/Message.ts
+++ b/packages/stentor-models/src/Message.ts
@@ -25,4 +25,10 @@ export interface Message {
      * Optional, more detailed information about the message
      */
     response?: ResponseOutput;
+    /**
+     * Optional, additional attributes that can exist on the message.
+     * 
+     * Useful to pass additional context.
+     */
+    attributes?: object;
 }

--- a/packages/stentor-models/src/Request/Request.ts
+++ b/packages/stentor-models/src/Request/Request.ts
@@ -105,6 +105,12 @@ export interface BaseRequest {
      * Currently only Google and Dialogflow perform health checks.
      */
     isHealthCheck?: boolean;
+    /**
+     * Optional request attributes to be passed through on the request.
+     * 
+     * If the channel supports it, it will be populated.
+     */
+    attributes?: object;
 }
 
 export interface ApiAccessData {

--- a/packages/stentor-runtime/src/__test__/main.storage.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.storage.test.ts
@@ -462,25 +462,25 @@ describe(`#${main.name}() storage`, () => {
                             {
                                 to: [{ id: "bot-id" }],
                                 from: { id: "real-person" },
-                                createdTime: "1",
+                                createdTime: "2022-03-11T22:44:16.979Z",
                                 message: "hi"
                             },
                             {
                                 to: [{ id: "real-person" }],
                                 from: { id: "bot" },
-                                createdTime: "2",
+                                createdTime: "2022-03-11T22:44:33.636Z",
                                 message: "hi, how are you"
                             },
                             {
                                 to: [{ id: "bot-id" }],
                                 from: { id: "real-person" },
-                                createdTime: "3",
+                                createdTime: "2022-03-11T22:44:49.995Z",
                                 message: "fine thanks, you?"
                             },
                             {
                                 to: [{ id: "real-person" }],
                                 from: { id: "bot-id" },
-                                createdTime: "4",
+                                createdTime: "2022-03-11T22:45:03.387Z",
                                 message: "i'm well, how can i help"
                             }
                         ]
@@ -503,7 +503,7 @@ describe(`#${main.name}() storage`, () => {
                 process.env.STUDIO_APP_ID = previousAppId;
                 process.env.STUDIO_MAX_HISTORY = previousMaxHistory;
             });
-            it('keeps the length to 20', async () => {
+            it.only('keeps the length to 20', async () => {
                 await main(
                     request,
                     context,
@@ -515,7 +515,7 @@ describe(`#${main.name}() storage`, () => {
                         handlerService,
                         userStorageService
                     }
-                )
+                );
 
                 expect(callbackSpy).to.have.been.calledOnce;
                 expect(userStorageService.update).to.have.been.calledOnce;

--- a/packages/stentor-runtime/src/__test__/main.storage.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.storage.test.ts
@@ -503,7 +503,7 @@ describe(`#${main.name}() storage`, () => {
                 process.env.STUDIO_APP_ID = previousAppId;
                 process.env.STUDIO_MAX_HISTORY = previousMaxHistory;
             });
-            it.only('keeps the length to 20', async () => {
+            it('keeps the length to 20', async () => {
                 await main(
                     request,
                     context,


### PR DESCRIPTION
* Adds an optional request attributes so we can leverage channels that already support them and pass them through.
* Replaces the previous CRM (still unused) service transcript with the same one on the session store.
