### PR TITLE
fix: Crash when outputSpeech doesn't exist

### DIFF
--- a/packages/stentor-runtime/src/__test__/Mocks.ts
+++ b/packages/stentor-runtime/src/__test__/Mocks.ts
@@ -117,6 +117,7 @@ export const MOCK_CHANNEL: Channel = {
 
 export interface PassThroughChannelOptions {
     device?: Device;
+    response?: Translator<RequestResponse, Response>;
     test?(body: object): boolean;
 }
 
@@ -157,7 +158,7 @@ export function passThroughChannel(options?: PassThroughChannelOptions): Channel
             }
         },
         request: new PassThroughRequestTranslator(),
-        response: new PassThroughResponseTranslator(),
+        response: options?.response || new PassThroughResponseTranslator(),
         capabilities: (): Device => {
             if (options && options.device) {
                 return options.device;

--- a/packages/stentor-runtime/src/main.ts
+++ b/packages/stentor-runtime/src/main.ts
@@ -562,7 +562,7 @@ export const main = async (
     }
 
     // Add the response to the transcript!
-    if (response) {
+    if (response && response.outputSpeech) {
 
         const id: string = APP_ID || "bot";
 


### PR DESCRIPTION
Fixes a bug where main would crash when outputspeech didn't exist.