### PR TITLE
fix: Changes object to record<string,unknown> on Request Attributes

### DIFF
--- a/packages/stentor-models/src/Request/Request.ts
+++ b/packages/stentor-models/src/Request/Request.ts
@@ -110,7 +110,7 @@ export interface BaseRequest {
      * 
      * If the channel supports it, it will be populated.
      */
-    attributes?: object;
+    attributes?: Record<string, unknown>;
 }
 
 export interface ApiAccessData {


### PR DESCRIPTION
We want the request attributes to be more accessible and `object` is hard to use.  This change is innocuous.

Challenges of `object`:

![image](https://user-images.githubusercontent.com/921356/159040183-796de155-eaf7-424d-ad25-504040aebed7.png)
