### PR TITLE
chore:Adding matchConfidence to NLUServiceResponse

### DIFF
--- a/packages/stentor-models/src/NLU/NLUService.ts
+++ b/packages/stentor-models/src/NLU/NLUService.ts
@@ -4,8 +4,18 @@ import { ActiveContext } from "../Response";
 
 export interface NLUQueryResponse {
     type: IntentRequestType | InputUnknownRequestType;
+    /**
+     * ID for the matched intent.
+     */
     intentId: string;
+    /**
+     * Optional slots for the matched intent.
+     */
     slots?: RequestSlotMap;
+    /**
+     * Confidence level of the intent match.  On a scale from 0-1 where 1 is the highest confidence of a match.
+     */
+    matchConfidence?: number;
     knowledgeAnswer?: KnowledgeAnswer;
 }
 


### PR DESCRIPTION
We want to surface the match confidence on the NLUService for use and capture.