### PR TITLE
fix: Check for null values in the compiler

### DIFF
--- a/packages/stentor-utils/src/compilers/__test__/compiler.test.ts
+++ b/packages/stentor-utils/src/compilers/__test__/compiler.test.ts
@@ -51,6 +51,10 @@ const sessionData = {
     output: {
         displayText: "session display text",
         ssml: "session ssml"
+    },
+    nullValue: {
+        // @ts-expect-error We are testing null values here
+        foo: null
     }
 }
 
@@ -376,6 +380,17 @@ describe(`${Compiler.name}`, () => {
                     ssml: "<speak>Hi bob vance!</speak>",
                     displayText: "Hi bob Vance!"
                 });
+            });
+        });
+        describe("when a resolved path value is null", () => {
+
+            it.only("compiles the values", () => {
+                const json = '{"description":"${currentResult.document}","title":"${nullValue.foo}","url":"${currentResult.source}","synonyms":[],"token":"result-${index}"}';
+
+                const compiled = new Compiler().compile(json, request, context);
+                console.log(compiled);
+                expect(compiled).to.exist;
+
             });
         });
     });

--- a/packages/stentor-utils/src/compilers/__test__/compiler.test.ts
+++ b/packages/stentor-utils/src/compilers/__test__/compiler.test.ts
@@ -383,13 +383,11 @@ describe(`${Compiler.name}`, () => {
             });
         });
         describe("when a resolved path value is null", () => {
-
-            it.only("compiles the values", () => {
+            it("compiles the values", () => {
                 const json = '{"description":"${currentResult.document}","title":"${nullValue.foo}","url":"${currentResult.source}","synonyms":[],"token":"result-${index}"}';
-
                 const compiled = new Compiler().compile(json, request, context);
-                console.log(compiled);
                 expect(compiled).to.exist;
+                expect(compiled).to.equal(json);
 
             });
         });

--- a/packages/stentor-utils/src/compilers/compiler.ts
+++ b/packages/stentor-utils/src/compilers/compiler.ts
@@ -21,7 +21,7 @@ export const DEFAULT_MARCOS: MacroMap = {
 
 export interface CompilerProps {
     /**
-     * When true, it will replace the ${foo} with undefined.  Default behavior will leave ${foo} if it does not have a value.
+     * When true, it will replace the ${foo} with undefined or null if the value for `foo` cannot be found.  Default behavior will leave ${foo} if it does not have a value.
      */
     readonly replaceWhenUndefined?: boolean;
     /**
@@ -166,7 +166,7 @@ export class Compiler implements CompilerProps {
 
                 const sessionReplacement = sessionPathResult[0];
 
-                if (typeof sessionReplacement === "object") {
+                if (sessionReplacement && typeof sessionReplacement === "object") {
                     // Try the key, it might be a ResponseOutput
                     if (sessionPathResult[0][key]) {
                         sessionValue = `${sessionReplacement[key]}`;
@@ -177,10 +177,9 @@ export class Compiler implements CompilerProps {
                     }
                 } else if (typeof sessionReplacement === "string") {
                     sessionValue = sessionReplacement
-                } else {
+                } else if (sessionReplacement !== null) {
                     sessionValue = `${sessionReplacement}`;
                 }
-
             }
             // Last, we just try a JSON path
             const pathResult = JSONPath({
@@ -197,7 +196,7 @@ export class Compiler implements CompilerProps {
 
                 const replacement = pathResult[0];
 
-                if (typeof replacement === "object") {
+                if (replacement && typeof replacement === "object") {
                     // Try the key, it might be a ResponseOutput
                     if (replacement[key]) {
                         pathReplacement = `${replacement[key]}`;
@@ -208,7 +207,7 @@ export class Compiler implements CompilerProps {
                     }
                 } else if (typeof replacement === "string") {
                     pathReplacement = replacement;
-                } else {
+                } else if (replacement !== null) {
                     pathReplacement = `${replacement}`;
                 }
             }


### PR DESCRIPTION
Was getting a crash when the session values were coming back as `null`.  We now look for `null` and protect against it.