### PR TITLE
fix: Removes support for markdown blocks

### DIFF
--- a/packages/stentor-utils/src/__test__/markdown.test.ts
+++ b/packages/stentor-utils/src/__test__/markdown.test.ts
@@ -25,6 +25,11 @@ describe(`#${toHTML.name}()`, () => {
             // Table support
             expect(toHTML("| Foo | Bar | \n  | --  | -- | \n  | one | two |")).to.equal("<table>\n<thead>\n<tr>\n<th>Foo</th>\n<th>Bar</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>one</td>\n<td>two</td>\n</tr>\n</tbody></table>\n");
             expect(toHTML("| Foo | Bar | \n  | --  | -- | \n  | one | two |")).to.equal("<table>\n<thead>\n<tr>\n<th>Foo</th>\n<th>Bar</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>one</td>\n<td>two</td>\n</tr>\n</tbody></table>\n");
+            // With potential codeblocks
+            const noBlocks = toHTML("Our **gutter** protection systems include:\n\n\tGutterglove Pro\n\tGutterglove Ultra\n\tLeaf Blaster\n\tGutterglove Icebreaker\n\nEach of these systems come");
+            expect(noBlocks).to.not.contain("<code>")
+            const noBlocks0 = toHTML("Here is what I found...\n\"\nGutterglove **Gutter** **Guards**\n\nGutterglove offers superior **gutter** protection with their patented Ultimate **Gutter** Protection System. Gutterglove offers a variety of **gutter** **guards** to fit your home and climate’s specific needs. Our **gutter** protection systems include:\n\n\tGutterglove Pro\n\tGutterglove Ultra\n\tLeaf Blaster\n\tGutterglove Icebreaker\n\nEach of these systems come in different sizes and styles to ensure a perfect match for your home.\n\nKey Benefits of Gutterglove **Gutter** **Guards**:\n\n\tEliminates **gutter** cleaning forever\n\tFilters out all debris from your **gutter**\n\tFirst Stage filter in rain harvesting systems\n\tBarely visible from the ground\n\tNo rain **gutter** clogs ever\" May I have your address where you need the service?");
+            expect(noBlocks0).to.not.contain("<code>");
         });
     });
     describe("when passed props", () => {

--- a/packages/stentor-utils/src/markdown.ts
+++ b/packages/stentor-utils/src/markdown.ts
@@ -29,11 +29,17 @@ export function toHTML(input: string, props?: { allowedTags?: string[] }): strin
 
     // From https://github.com/markedjs/marked/issues/655#issuecomment-383226346
     const renderer = new marked.Renderer();
+    // copy the existing link renderer for use later
     const linkRenderer = renderer.link;
+    // override it by calling the original then changing it out to use target _blank
     renderer.link = (href, title, text): string => {
         const html = linkRenderer.call(renderer, href, title, text);
         return html.replace(/^<a /, `<a target="_blank" rel="nofollow" `);
     };
+    // Just disable it by passing it through.  It messes with the formatting too much
+    renderer.code = (code): string => {
+        return code;
+    }
     const dirty = marked(linked, { renderer, breaks: true, xhtml: true });
 
     const clean = sanitize(dirty, props);


### PR DESCRIPTION
Code Blocks, `<code>` caused some oddities when we attempted to display them in the messages:  

![image](https://user-images.githubusercontent.com/921356/164532358-ce1fbdfc-89bd-4c08-88c8-f0c23b89cb94.png)

This disables them, which is ok as they weren't technically supported in the first place: https://documentation.xapp.ai/docs/content/responses#display-text