### PR TITLE
fix: Better compatibility with CloudWatch logs

### DIFF
--- a/packages/stentor-logger/src/__test__/logger.test.ts
+++ b/packages/stentor-logger/src/__test__/logger.test.ts
@@ -12,6 +12,7 @@ let logLevel: string;
 let logPii: string;
 let maskPartial: string;
 
+
 beforeEach(() => {
     logLevel = process.env.STENTOR_LOG_LEVEL;
     logPii = process.env.OVAI_LOG_PII;
@@ -48,6 +49,36 @@ describe("#log()", () => {
                 }
             });
         }).to.not.throw();
+    });
+    describe("when on lambda", () => {
+        beforeEach(() => {
+            process.env.AWS_LAMBDA_FUNCTION_NAME = "debug-func";
+        });
+        afterEach(() => {
+            delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+        });
+        it("prints correctly", () => {
+            expect(() => {
+                log().debug("foo");
+                log().info("bar");
+                log().warn("warn");
+                log().debug("foo %o", { bar: true });
+                log().debug({ bar: true });
+                log().error(new Error("foo"));
+                log().debug("my number is 800-888-8888");
+                log().debug({
+                    number: "8008888888"
+                });
+                log().debug({
+                    email: "foo@xappmedia.com",
+                    phone: "800.888.8888",
+                    bar: true,
+                    foo: {
+                        baz: 6
+                    }
+                });
+            }).to.not.throw();
+        });
     });
 });
 describe("#set()", () => {


### PR DESCRIPTION
`stentor-logger` was pretty printing JSON which can be nice for local console however in CloudWatch it just pollutes your log statements with the new lines.

This detects if we are on AWS Lambda and then does not pretty print JSON objects.