### PR TITLE
fix: Adding EventService to runtime context

### DIFF
--- a/packages/stentor-context/src/ContextFactory.ts
+++ b/packages/stentor-context/src/ContextFactory.ts
@@ -7,6 +7,7 @@ import {
     Context,
     CrmService,
     Device,
+    ErrorService,
     Pii,
     PIIService,
     Request,
@@ -26,6 +27,7 @@ export interface ContextFactoryServices {
     piiService: PIIService;
     crmService?: CrmService;
     smsService?: SMSService;
+    eventService?: ErrorService;
 }
 
 export class ContextFactory {
@@ -46,7 +48,7 @@ export class ContextFactory {
         channel: Channel,
         appData?: AppRuntimeData
     ): Promise<Readonly<Context>> {
-        const { userStorageService, piiService, crmService, smsService } = services;
+        const { userStorageService, piiService, crmService, eventService, smsService } = services;
 
         const device: Device = channel.capabilities(requestBody);
 
@@ -164,7 +166,8 @@ export class ContextFactory {
             pii,
             services: {
                 crmService,
-                smsService
+                smsService,
+                eventService
             }
         };
     }

--- a/packages/stentor-models/src/Context.ts
+++ b/packages/stentor-models/src/Context.ts
@@ -5,7 +5,7 @@ import { AbstractResponseBuilder } from "./Response";
 import { SessionStore, Storage } from "./Storage";
 import { UserDataType } from "./UserData";
 import { UserProfile } from "./UserProfile";
-import { CrmService, SMSService } from "./Services";
+import { CrmService, ErrorService, SMSService } from "./Services";
 
 export enum UserDataRequestStatus {
     DEFERRED,
@@ -21,6 +21,7 @@ export interface UserDataValue {
 
 export type UserData = (userDataType: UserDataType) => Promise<UserDataRequestStatus>;
 
+
 /**
  * These we want to make available for custom handlers
  */
@@ -33,6 +34,10 @@ export interface ContextServices {
      * Service for sending text messages
      */
     smsService?: SMSService;
+    /**
+     * Access to the event service for reporting runtime errors.
+     */
+    eventService?: ErrorService;
 }
 
 /**

--- a/packages/stentor-models/src/Services/ErrorService.ts
+++ b/packages/stentor-models/src/Services/ErrorService.ts
@@ -1,0 +1,6 @@
+/*! Copyright (c) 2022, XAPPmedia */
+import { ErrorEvent } from "../Events";
+
+export interface ErrorService {
+    error(error: Error): ErrorEvent;
+}

--- a/packages/stentor-models/src/Services/index.ts
+++ b/packages/stentor-models/src/Services/index.ts
@@ -1,7 +1,8 @@
 /*! Copyright (c) 2019, XAPPmedia */
 export * from "./AppService";
-export * from "./HandlerService";
 export * from "./CrmService";
+export * from "./ErrorService";
+export * from "./HandlerService";
 export * from "./KnowledgeBaseService";
 export * from "./PIIService";
 export * from "./SMSService";

--- a/packages/stentor-runtime/src/main.ts
+++ b/packages/stentor-runtime/src/main.ts
@@ -260,6 +260,7 @@ export const main = async (
                 userStorageService,
                 piiService,
                 crmService,
+                eventService,
                 smsService
             },
             channel,

--- a/packages/stentor-service-event/src/EventService.ts
+++ b/packages/stentor-service-event/src/EventService.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-console */
 import {
     ErrorEvent,
+    ErrorService,
     Event,
     EventStream,
     EventType,
@@ -52,7 +53,6 @@ function getPrefix(prefix: EventPrefix): PrefixObject {
     }, {});
 }
 
-
 function containsSameKeys(obj1: object = {}, obj2: object = {}): boolean {
     const obj1Keys = Object.keys(obj1);
     const obj2Keys = Object.keys(obj2);
@@ -76,7 +76,7 @@ export interface EventServiceProps {
     prefix?: EventPrefix;
 }
 
-export class EventService {
+export class EventService implements ErrorService {
     private readonly streams: EventStream[];
     private prefix: EventPrefix = {
         // default values
@@ -223,7 +223,6 @@ export class EventService {
 
     /**
      * Add an event that will be sent to all event streams.
-     * 
      */
     public event(stentorEvent: Event<any>): Event<any>;
     public event(type: EventType, name: string, payload?: string | object, keys?: Record<string, unknown>): Event<any>;


### PR DESCRIPTION
This exposes the event service on the runtime context for reporting errors!  This will allow us to send runtime errors from external APIs to Studio (or other) for tracking.