### PR TITLE
fix: Ability to select KB Service based on Channel

### DIFF
--- a/packages/stentor-models/src/Knowledgebase/KnowledgeBaseConfig.ts
+++ b/packages/stentor-models/src/Knowledgebase/KnowledgeBaseConfig.ts
@@ -9,6 +9,12 @@ export interface KnowledgeBaseConfig {
      */
     matchIntentId?: string;
     /**
+     * Either exact name of the channel or a regex to determine which channel to call the KnowledgeBaseService.
+     * 
+     * If this matches, all requests from this channel go to the KnowledgeBaseService regardless if matchIntentId is set.
+     */
+    matchChannel?: string;
+    /**
      * If provided, it will override the intentId on the original request if the knowledgebase results are preferred.
      * 
      * It will also update the request type to be that of an Intent Request.
@@ -24,6 +30,8 @@ export interface KnowledgeBaseConfig {
     // For future consideration
     // If set, it will be used to establish a minimum threshold that must be passed in order to use the knowledge base results.
     // If below the threshold, then the existing intent will be used and not augmented.
+    // This is only a consideration right now because NLUs like Lex will typically handle this logic for you based on a setting
+    // you provide them.  
     // confidenceThreshold?: number;
 }
 

--- a/packages/stentor-request/src/Builders.ts
+++ b/packages/stentor-request/src/Builders.ts
@@ -51,6 +51,8 @@ import * as INTENT from "stentor-interaction-model/lib/Intent/Constants";
 export class LaunchRequestBuilder extends AbstractBuilder<LaunchRequest> {
     private accessToken?: string;
     private deviceId = "deviceId";
+    private channel?: string;
+    private platform?: string;
 
     /**
      * Add a access token to the request.
@@ -73,12 +75,33 @@ export class LaunchRequestBuilder extends AbstractBuilder<LaunchRequest> {
     }
 
     /**
+ * Set the platform for the request.
+ *
+ * @param platform - Platform for the request
+ */
+    public onPlatform(platform: string): LaunchRequestBuilder {
+        this.platform = platform;
+        return this;
+    }
+
+    /**
+     * Set the channel for the request 
+     * 
+     * @param channel - Channel for the request
+     * @returns 
+     */
+    public onChannel(channel: string): LaunchRequestBuilder {
+        this.channel = channel;
+        return this;
+    }
+
+    /**
      * Build the request.
      */
     public build(): LaunchRequest {
         const { accessToken, deviceId } = this;
 
-        return {
+        const request: LaunchRequest = {
             intentId: LAUNCH_REQUEST_ID,
             type: LAUNCH_REQUEST_TYPE,
             isNewSession: true,
@@ -87,6 +110,16 @@ export class LaunchRequestBuilder extends AbstractBuilder<LaunchRequest> {
             userId: "userId",
             accessToken
         };
+
+        if (this.channel) {
+            request.channel = this.channel;
+        }
+
+        if (this.platform) {
+            request.platform = this.platform;
+        }
+
+        return request;
     }
 }
 
@@ -98,6 +131,29 @@ export class LaunchRequestBuilder extends AbstractBuilder<LaunchRequest> {
 export class InputUnknownRequestBuilder extends AbstractBuilder<InputUnknownRequest> {
     private deviceId = "deviceId";
     private rawQuery: string;
+    private channel?: string;
+    private platform?: string;
+
+    /**
+ * Set the platform for the request.
+ *
+ * @param platform - Platform for the request
+ */
+    public onPlatform(platform: string): InputUnknownRequestBuilder {
+        this.platform = platform;
+        return this;
+    }
+
+    /**
+     * Set the channel for the request 
+     * 
+     * @param channel - Channel for the request
+     * @returns 
+     */
+    public onChannel(channel: string): InputUnknownRequestBuilder {
+        this.channel = channel;
+        return this;
+    }
 
     /**
      * Add a device ID to the request.
@@ -133,6 +189,14 @@ export class InputUnknownRequestBuilder extends AbstractBuilder<InputUnknownRequ
             request.rawQuery = this.rawQuery;
         }
 
+        if (this.channel) {
+            request.channel = this.channel;
+        }
+
+        if (this.platform) {
+            request.platform = this.platform;
+        }
+
         return request;
     }
 }
@@ -147,6 +211,7 @@ export class InputUnknownRequestBuilder extends AbstractBuilder<InputUnknownRequ
  */
 export class IntentRequestBuilder extends AbstractBuilder<IntentRequest> {
     private apiAccess: ApiAccessData;
+    private channel: string;
     private deviceId = "deviceId";
     private intentId = "intentId";
     private isNewSession = false;
@@ -185,6 +250,17 @@ export class IntentRequestBuilder extends AbstractBuilder<IntentRequest> {
      */
     public onPlatform(platform: string): IntentRequestBuilder {
         this.platform = platform;
+        return this;
+    }
+
+    /**
+     * Set the channel for the request 
+     * 
+     * @param channel - Channel for the request
+     * @returns 
+     */
+    public onChannel(channel: string): IntentRequestBuilder {
+        this.channel = channel;
         return this;
     }
 
@@ -345,7 +421,7 @@ export class IntentRequestBuilder extends AbstractBuilder<IntentRequest> {
      * Build the intent request.
      */
     public build(): IntentRequest {
-        const { apiAccess, canFulFill, device, deviceId, knowledgeBaseResult, intentId, locale, platform, slots, userId, isNewSession, rawQuery } = this;
+        const { apiAccess, canFulFill, channel, device, deviceId, knowledgeBaseResult, intentId, locale, platform, slots, userId, isNewSession, rawQuery } = this;
 
         const request: IntentRequest = {
             type: INTENT_REQUEST_TYPE,
@@ -364,6 +440,10 @@ export class IntentRequestBuilder extends AbstractBuilder<IntentRequest> {
 
         if (rawQuery) {
             request.rawQuery = rawQuery;
+        }
+
+        if (channel) {
+            request.channel = channel;
         }
 
         if (platform) {

--- a/packages/stentor-runtime/src/__test__/main.knowledgebase.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.knowledgebase.test.ts
@@ -58,7 +58,9 @@ describe("#main() with KnowledgeBase Service", () => {
     let handlerService: HandlerService;
     let userStorageService: UserStorageService;
     let knowledgeBaseService: KnowledgeBaseService;
+    let wrongKbService: KnowledgeBaseService;
     let querySpy: sinon.SinonSpy;
+    let wrongQuerySpy: sinon.SinonSpy;
 
     describe("when knowledge base service matches the request", () => {
         beforeEach(() => {
@@ -153,6 +155,63 @@ describe("#main() with KnowledgeBase Service", () => {
                     ssml: '<speak>Can you please say it again?</speak>',
                     displayText: 'Can you please say it again?'
                 }
+            });
+        });
+    });
+    describe("when a knowledge base service matches the channel", () => {
+        beforeEach(() => {
+            request = new IntentRequestBuilder().withRawQuery("what is your favorite scary movie").withIntentId(intentId).onChannel("Foo-channel").build();
+            handlerFactory = new HandlerFactory({ handlers: [ConversationHandler] });
+            context = { ovai: { appId } };
+            callbackSpy = sinon.spy();
+            handlerService = sinon.createStubInstance(MockHandlerService, {
+                get: intentHandler
+            });
+            userStorageService = sinon.createStubInstance(MockUserStorageService, {
+                get: Promise.resolve({ ...storage })
+            });
+            knowledgeBaseService = new MockKnowledgeBaseService();
+            wrongKbService = new MockKnowledgeBaseService();
+
+            querySpy = sinon.spy(knowledgeBaseService, "query");
+            wrongQuerySpy = sinon.spy(wrongKbService, "query");
+        });
+        it("calls the knowledgebase service", async () => {
+
+            await main(request, context, callbackSpy, [passThroughChannel()], {
+                handlerFactory,
+                handlerService,
+                userStorageService,
+                knowledgeBaseServices: {
+                    ["Foo.*"]: { matchChannel: "Foo.*", service: knowledgeBaseService },
+                    ["FooIntent"]: { matchIntentId: "FooIntent", service: wrongKbService }
+                }
+            });
+
+            expect(querySpy).to.have.been.calledOnce;
+            expect(wrongQuerySpy).to.have.not.been.called;
+
+            expect(callbackSpy).to.have.been.calledOnce;
+            expect(callbackSpy).to.have.been.calledWith(null, {
+                name: "Name",
+                outputSpeech: {
+                    // This is what the Mock returns in the first FAQ
+                    displayText: "Scream 2",
+                    ssml: "<speak>Scream 2</speak>"
+                }
+            });
+            // it sets the knowledge base result on the session
+            expect(userStorageService.update).to.have.been.calledOnce;
+            // @ts-ignore Sinon types seem to be incorrect.
+            const storage = userStorageService.update.getCall(0).args[1];
+            const result = storage.sessionStore.data.knowledge_base_result;
+            expect(result).to.deep.equal({
+                faqs: [
+                    {
+                        question: "What is your favorite scary movie?",
+                        document: "Scream 2"
+                    }
+                ]
             });
         });
     });

--- a/packages/stentor/src/Assistant.ts
+++ b/packages/stentor/src/Assistant.ts
@@ -124,8 +124,14 @@ export class Assistant {
      */
     public withKnowledgeBaseService(service: KnowledgeBaseService, config: KnowledgeBaseConfig): Assistant {
         if (service && config) {
+            // Channel take precedence over matchIntentId
+            let key = config.matchChannel || config.matchIntentId;
+
             // If they do not provide one, default is to be called on every request.
-            const key = config.matchIntentId || "^.*$";
+            if (!key) {
+                key = "^.*$";
+                config.matchIntentId = key;
+            }
             this.knowledgeBaseServices[key] = { service, ...config };
         }
         return this;

--- a/packages/stentor/src/__test__/Assistant.test.ts
+++ b/packages/stentor/src/__test__/Assistant.test.ts
@@ -95,7 +95,6 @@ const MockLambdaContext: AWSLambda.Context = {
     succeed: () => {
         return;
     }
-
 }
 
 describe("Assistant", () => {


### PR DESCRIPTION
For some channels, like intelligent-search, we want all requests to go to the KBService.  This adds a new field to the KBConfig to add `matchChannel`.  If this exists it takes precedence over `matchIntentId`