### PR TITLE
fix: Adding Sentiment Analysis Information to IntentRequest and InputUnknownRequest

### DIFF
--- a/packages/stentor-models/src/Request/InputUnknownRequest.ts
+++ b/packages/stentor-models/src/Request/InputUnknownRequest.ts
@@ -1,11 +1,11 @@
 /*! Copyright (c) 2019, XAPPmedia */
 import { KnowledgeBaseResult } from "./KnowledgeBase";
-import { BaseRequest } from "./Request";
+import { BaseRequest, SentimentedRequest } from "./Request";
 import { InputUnknownID, InputUnknownRequestType } from "./Types";
 /**
  * Request when a user requests something not in the interaction model.
  */
-export interface InputUnknownRequest extends BaseRequest {
+export interface InputUnknownRequest extends BaseRequest, SentimentedRequest {
     type: InputUnknownRequestType;
     /**
      * Input Unknowns have a constant intentId.

--- a/packages/stentor-models/src/Request/IntentRequest.ts
+++ b/packages/stentor-models/src/Request/IntentRequest.ts
@@ -1,7 +1,7 @@
 /*! Copyright (c) 2019, XAPPmedia */
 import { DateTime, DateTimeRange, Duration } from "../DateTime";
 import { Data } from "../Handler";
-import { BaseRequest } from "./Request";
+import { BaseRequest, SentimentedRequest } from "./Request";
 import { IntentRequestType } from "./Types";
 import { KnowledgeAnswer, KnowledgeBaseResult } from "./KnowledgeBase";
 
@@ -80,7 +80,7 @@ export interface RequestSlotMap {
  *
  * For Alexa see {@link https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/handling-requests-sent-by-alexa#intentrequest}
  */
-export interface IntentRequest extends BaseRequest {
+export interface IntentRequest extends BaseRequest, SentimentedRequest {
     /**
      * The type of an intent request is always "INTENT_REQUEST"
      */

--- a/packages/stentor-models/src/Request/Request.ts
+++ b/packages/stentor-models/src/Request/Request.ts
@@ -116,6 +116,32 @@ export interface BaseRequest {
     attributes?: Record<string, unknown>;
 }
 
+/**
+ * A request with sentiment analysis information
+ */
+export interface SentimentedRequest {
+    /**
+     * An analysis on the user's query text sentiment
+     */
+    sentimentAnalysis?: {
+        /**
+         * An abstracted measure of the sentiment. 
+         * 
+         * * POSITIVE - Query has positive sentiment
+         * * NEUTRAL - Query has either positive or negative sentiment
+         * * NEGATIVE - Query has negative sentiment
+         * * MIXED - Query has both positive and negative sentiment
+         */
+        sentiment: "POSITIVE" | "NEUTRAL" | "NEGATIVE" | "MIXED";
+        /**
+         * The original payload from the sentiment analysis engine stringified
+         * 
+         * You can use `JSON.parse` on this data to extract more information.
+         */
+        original?: string;
+    }
+}
+
 export interface ApiAccessData {
     apiBaseUrl: string;
     apiAuthToken: string;


### PR DESCRIPTION
This prepares us for Dialogflow ES & Lex V2 style sentiment information appended to requests.

Reference

* Lex V2 / [Comprehend](https://docs.aws.amazon.com/comprehend/latest/dg/how-sentiment.html)
* [Dialogflow ES](https://cloud.google.com/dialogflow/es/docs/reference/rest/v2beta1/SentimentAnalysisResult)