### PR TITLE
chore: Add extras to CRM Service Send

### DIFF
--- a/packages/stentor-models/src/Services/CrmService.ts
+++ b/packages/stentor-models/src/Services/CrmService.ts
@@ -4,8 +4,10 @@ import { CrmResponse, ExternalLead } from "../Crm";
 
 export interface CrmService {
     /**
-     *
-     * @param externalLead
+     * Send the lead to the CRM
+     * 
+     * @param externalLead Lead information
+     * @param extras Optional additional metadata to pass to the CRM
      */
-    send(externalLead: ExternalLead): Promise<CrmResponse>;
+    send(externalLead: ExternalLead, extras?: Record<string, unknown>): Promise<CrmResponse>;
 }


### PR DESCRIPTION
Adds optional ability to send additional metadata to your CRM Service without first extending it.