### PR TITLE
fix: Set Context Support for Stentor Channel

### DIFF
--- a/packages/stentor-channel/package.json
+++ b/packages/stentor-channel/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@xapp/patterns": "1.40.297",
+    "stentor-logger": "1.56.99",
     "stentor-utils": "1.56.99"
   },
   "peerDependencies": {

--- a/packages/stentor-models/src/Channel/Channel.ts
+++ b/packages/stentor-models/src/Channel/Channel.ts
@@ -14,7 +14,7 @@ export interface RequestResponse {
     response: Response;
 }
 
-export type ChannelHooks = Pick<Hooks, "preExecution" | "postRequestTranslation">;
+export type ChannelHooks = Pick<Hooks, "preExecution" | "postRequestTranslation" | "preResponseTranslation">;
 
 export interface Channel {
     /**

--- a/packages/stentor-models/src/UtteranceTest.ts
+++ b/packages/stentor-models/src/UtteranceTest.ts
@@ -1,6 +1,7 @@
 /*! Copyright (c) 2020, XAPPmedia */
 import { RelativeDateTime } from "./DateTime"
 import { RequestSlot, RequestSlotValues } from "./Request";
+import { ActiveContext } from "./Response";
 
 /**
  * Extends a RequestSlot by adding the RelativeDateTime as a possible value.
@@ -31,6 +32,10 @@ export interface UtteranceTest {
      * The utterance to be tested
      */
     utterance: string;
+    /**
+     * Optional active context required for the utterance to trigger the expected inent.
+     */
+    activeContext?: ActiveContext[];
     /**
      * The expected result once the utterance is passed in the NLU
      */

--- a/packages/stentor-runtime/src/__test__/Mocks.ts
+++ b/packages/stentor-runtime/src/__test__/Mocks.ts
@@ -3,6 +3,7 @@
 import { Translator } from "@xapp/patterns";
 import {
     Channel,
+    ChannelHooks,
     Device,
     HandlerService,
     KnowledgeBaseResult,
@@ -21,6 +22,10 @@ import {
 export class MockNLUService implements NLUService {
     public async query(): Promise<NLUQueryResponse> {
         return {} as any;
+    }
+
+    public async setContext(): Promise<void> {
+        return;
     }
 }
 
@@ -127,6 +132,7 @@ export interface PassThroughChannelOptions {
     device?: Device;
     response?: Translator<RequestResponse, Response>;
     nlu?: NLUService;
+    hooks?: ChannelHooks;
     test?(body: object): boolean;
 }
 
@@ -169,6 +175,7 @@ export function passThroughChannel(options?: PassThroughChannelOptions): Channel
                 return true;
             }
         },
+        hooks: options?.hooks,
         request: new PassThroughRequestTranslator(),
         response: options?.response || new PassThroughResponseTranslator(),
         capabilities: (): Device => {

--- a/packages/stentor-runtime/src/__test__/main.channels.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.channels.test.ts
@@ -1,0 +1,124 @@
+/*! Copyright (c) 2022, XAPP AI */
+import * as chai from "chai";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+import { ConversationHandler } from "stentor-handler";
+import { HandlerFactory } from "stentor-handler-factory";
+import {
+    Content,
+    Handler,
+    HandlerService,
+    NLUService,
+    NLUQueryResponse,
+    Storage,
+    UserStorageService
+} from "stentor-models";
+import { LaunchRequestBuilder } from "stentor-request";
+import { EventService } from "stentor-service-event";
+
+import { main } from "../main";
+import { MockHandlerService, MockNLUService, MockUserStorageService, passThroughChannel } from "./Mocks";
+
+const appId = "appId";
+const intentId = "intentId";
+
+const content: Content = {
+    ["LaunchRequest"]: [
+        {
+            name: "Name",
+            outputSpeech: "Hello World!"
+        }
+    ]
+};
+
+const handler: Handler = {
+    organizationId: "organizationId",
+    appId,
+    intentId: "LaunchRequest",
+    name: "Launch Request",
+    type: "ConversationHandler",
+    content,
+    data: {}
+};
+
+const intentResponse: NLUQueryResponse = {
+    type: "INTENT_REQUEST",
+    intentId
+}
+
+const createdDate = new Date();
+createdDate.setDate(createdDate.getDate() - 1);
+
+const storage: Storage = {
+    createdTimestamp: createdDate.getTime(),
+    lastActiveTimestamp: createdDate.getTime(),
+    sessionStore: { id: "fakeSession", data: {} }
+};
+
+describe("#main() with channels", () => {
+    let request: any;
+    let context: any;
+    let handlerFactory: HandlerFactory;
+    let callbackSpy: sinon.SinonSpy;
+    let preResponseTranslationSpy: sinon.SinonSpy;
+    let handlerService: HandlerService;
+    let userStorageService: UserStorageService;
+    let eventService: EventService;
+    let nlu: NLUService;
+    beforeEach(() => {
+        eventService = new EventService();
+        eventService.addPrefix({ appId });
+    });
+    describe("that have hooks", () => {
+        beforeEach(() => {
+            request = new LaunchRequestBuilder().build();
+            handlerFactory = new HandlerFactory({ handlers: [ConversationHandler] });
+            context = { ovai: { appId } };
+            callbackSpy = sinon.spy();
+            preResponseTranslationSpy = sinon.spy();
+            handlerService = sinon.createStubInstance(MockHandlerService, {
+                get: handler
+            });
+            userStorageService = sinon.createStubInstance(MockUserStorageService, {
+                get: Promise.resolve({ ...storage })
+            });
+            nlu = sinon.createStubInstance(MockNLUService, {
+                query: Promise.resolve(intentResponse),
+                setContext: Promise.resolve()
+            });
+        });
+        it("are called correct", async () => {
+
+            await main(
+                request,
+                context,
+                callbackSpy,
+                [passThroughChannel({ hooks: { preResponseTranslation: preResponseTranslationSpy }, nlu })],
+                {
+                    eventService,
+                    handlerFactory,
+                    handlerService,
+                    userStorageService
+                }
+            );
+
+            expect(callbackSpy).to.have.been.calledOnce;
+            const arg = callbackSpy.getCall(0);
+            expect(arg.args).to.have.length(2);
+            expect(arg.args[0]).to.be.null;
+            expect(arg.args[1]).to.deep.equal({
+                "name": "Name",
+                "outputSpeech": {
+                    "displayText": "Hello World!",
+                    "ssml": "<speak>Hello World!</speak>"
+                }
+            });
+
+            expect(preResponseTranslationSpy).to.have.been.calledOnce;
+        });
+    })
+});

--- a/packages/stentor-runtime/src/__test__/main.hooks.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.hooks.test.ts
@@ -375,7 +375,7 @@ describe("#main() with hooks", () => {
             );
 
             const userStore = await userStorageService.get("fakeUserId");
-            const transcript = userStore.sessionStore.data.transcript;
+            const transcript = userStore?.sessionStore?.data.transcript;
 
             expect(transcript).exist;
             expect(transcript.length).equals(2);

--- a/packages/stentor-runtime/src/main.ts
+++ b/packages/stentor-runtime/src/main.ts
@@ -506,7 +506,15 @@ export const main = async (
     }
 
     // preResponseTranslation hook - only real content (leave the errors alone)
-    if (typeof hooks === "object" && typeof hooks.preResponseTranslation === "function") {
+    if (!!channel.hooks && typeof channel.hooks.preResponseTranslation === "function") {
+        const returns = await channel.hooks.preResponseTranslation(request, context.response, context.storage);
+        if (returns) {
+            request = returns.request;
+            context.response = returns.response;
+            context.storage = returns.storage;
+        }
+    }
+    if (!!hooks && typeof hooks === "object" && typeof hooks.preResponseTranslation === "function") {
         const returns = await hooks.preResponseTranslation(request, context.response, context.storage);
         if (returns) {
             request = returns.request;


### PR DESCRIPTION
When we pass an NLU to the Stentor channel, we now automatically set the hook to send the context to the NLU for the response.