### PR TITLE
chore: Podcast Search Service

### DIFF
--- a/packages/stentor-models/src/Services/PodcastSearchService.ts
+++ b/packages/stentor-models/src/Services/PodcastSearchService.ts
@@ -1,0 +1,10 @@
+/*! Copyright (c) 2022, XAPP AI */
+import { PodcastEpisode } from "../Media";
+
+export interface PodcastSearchService {
+    queryOnly: boolean;
+    queryPodcastEpisode(podcastIds: string[], q: string): Promise<PodcastEpisode[]>;
+    storePodcastEpisode(podcastId: string, episode: PodcastEpisode): Promise<void>;
+    loadPodcastEpisode(podcastIds: string[]): Promise<PodcastEpisode[]>;
+    removePodcastEpisode(podcastId: string, episode: PodcastEpisode): Promise<void>;
+}

--- a/packages/stentor-models/src/Services/index.ts
+++ b/packages/stentor-models/src/Services/index.ts
@@ -5,5 +5,6 @@ export * from "./ErrorService";
 export * from "./HandlerService";
 export * from "./KnowledgeBaseService";
 export * from "./PIIService";
+export * from "./PodcastSearchService";
 export * from "./SMSService";
 export * from "./UserStorageService";


### PR DESCRIPTION
Part of cleaning up other repositories, moving this to models allows us to clean up some dependencies in other repositories.