### PR TITLE
fix: VM2 now optional dependency

### DIFF
--- a/packages/stentor-conditional/README.md
+++ b/packages/stentor-conditional/README.md
@@ -1,0 +1,9 @@
+### stentor-conditional
+
+Conditionals are objects with key `conditions` that are strings with simple expressions.
+
+The conditional determiner will take an array of conditionals and evaluate each condition and return an array of all the conditionals that returned true.
+
+### VM
+
+By default, it uses the built-in Node VM but if you install vm2 or isolated-vm, it will then prefer that as your VM environment.

--- a/packages/stentor-conditional/package.json
+++ b/packages/stentor-conditional/package.json
@@ -21,10 +21,15 @@
     "chai": "4.3.6",
     "mocha": "9.2.2",
     "stentor-models": "1.56.118",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "isolated-vm": "4.4.2",
+    "vm2": "3.9.11"
   },
   "dependencies": {
-    "stentor-logger": "1.56.118",
+    "stentor-logger": "1.56.118"
+  },
+  "optionalDependencies": {
+    "isolated-vm": "4.4.2",
     "vm2": "3.9.11"
   },
   "peerDependencies": {

--- a/packages/stentor-conditional/src/ConditionalDeterminer.ts
+++ b/packages/stentor-conditional/src/ConditionalDeterminer.ts
@@ -1,8 +1,8 @@
 /*! Copyright (c) 2020, XAPPmedia */
 import { log } from "stentor-logger";
 import { Contexts, ConditionalCheck, Conditional } from "stentor-models";
-import { VM } from "vm2";
 
+import { getVM, SandboxFunctions } from "./getVM";
 /**
  * ConditionalDeterminer is first configured with a set of conditional 
  * checks it can perform and then determines which is the best match.
@@ -41,7 +41,7 @@ export class ConditionalDeterminer {
         conditionals.forEach((conditional) => {
             if (typeof conditional.conditions === "string") {
                 // Get all the function and add them to the sandbox.
-                const sandboxFunctions: { [name: string]: ((input: any) => boolean | string | number) } = {};
+                const sandboxFunctions: SandboxFunctions = {};
 
                 if (Array.isArray(this.checks)) {
                     this.checks.forEach((check) => {
@@ -59,17 +59,20 @@ export class ConditionalDeterminer {
                     });
                 }
 
-                const vm = new VM({
+                const vm = getVM({
                     timeout: this.timeout,
                     sandbox: {
                         ...sandboxFunctions
                     }
                 });
+
                 let result: boolean;
                 try {
                     result = vm.run(conditional.conditions);
                 } catch (e) {
-                    log().error(`Error evaluating conditions "${conditional.conditions}": ${e}`);
+                    log().error(`${vm.type}|Error evaluating conditions "${conditional.conditions}": ${e}`);
+
+
                     result = false;
                 }
                 // It should be a boolean but need to double check

--- a/packages/stentor-conditional/src/getVM.ts
+++ b/packages/stentor-conditional/src/getVM.ts
@@ -1,0 +1,78 @@
+/*! Copyright (c) 2022, XAPP AI */
+
+import { runInNewContext, createContext } from "node:vm";
+
+export interface VMable {
+    run(code: string): boolean;
+
+    type: string;
+}
+
+export type SandboxFunctions = { [name: string]: ((input: any) => boolean | string | number) }
+
+export interface VMProps {
+    timeout: number;
+    sandbox: SandboxFunctions;
+}
+
+/**
+ * Returns a VM, defaults to Node's VM.
+ * 
+ * @param props 
+ * @returns 
+ */
+export function getVM(props: VMProps): VMable {
+
+    let vm: VMable = {
+        run: (code: string): boolean => {
+            const context = createContext(props.sandbox);
+            return runInNewContext(code, context);
+        },
+        type: "VM"
+    }
+
+    if (!process.env.SKIP_VM2) {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { VM } = require('vm2');
+            vm = new VM(props);
+            vm.type = "VM2";
+        } catch (e) {
+            // vm2 doesn't exist
+        }
+    }
+
+    if (!process.env.SKIP_IVM) {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const ivm = require('isolated-vm');
+            const isolate = new ivm.Isolate({ memoryLimit: 128 });
+            vm = {
+                run: (code: string): boolean => {
+
+                    const context = isolate.createContextSync();
+
+                    const jail = context.global;
+
+                    Object.keys(props.sandbox).forEach((fnc) => {
+                        const value = props.sandbox[fnc];
+                        jail.setSync(fnc, (...args: any) => {
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore
+                            return value(...args);
+                        });
+                    });
+
+                    return context.evalSync(code);
+                },
+                type: "IVM"
+            }
+
+        } catch (e) {
+
+        }
+    }
+
+    return vm;
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,10 +1895,15 @@ acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.7.0:
+acorn@^8.4.1:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+acorn@^8.7.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 acorn@^8.8.0:
   version "8.8.0"
@@ -4587,6 +4592,11 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isolated-vm@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/isolated-vm/-/isolated-vm-4.4.2.tgz#d5cf66f8751e9824cf0710d1a41022a1a60d29b7"
+  integrity sha512-4ObzqZWZTS3bQtavzgoCMsOxpQt3hMeenkPavx2Razig3wX3fAkXZ3XpmqXKoJu6KMl4egBI1MfSg0BnxZ/rfg==
 
 isomorphic-fetch@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
For all those having build issues with VM2, it is not optional dependency.  If VM2 is not installed, is uses Node's built-in VM module.  Furthermore, you can also use [isolated-vm](https://www.npmjs.com/package/isolated-vm) which gives you access to V8's Isolate interface, which is an isolated JS runtime.