### PR TITLE
chore: Removes isolvated-vm from optional dependencies (but still supporting it)

### DIFF
--- a/packages/stentor-conditional/README.md
+++ b/packages/stentor-conditional/README.md
@@ -6,4 +6,6 @@ The conditional determiner will take an array of conditionals and evaluate each 
 
 ### VM
 
-By default, it uses the built-in Node VM but if you install vm2 or isolated-vm, it will then prefer that as your VM environment.
+By default, it uses the built-in Node VM but if you install [vm2](https://github.com/patriksimek/vm2) or [isolated-vm](https://github.com/laverdet/isolated-vm), it will then prefer either of those as your VM environment.
+
+Note: `isolated-vm` is not in the `optionalDependencies` of the package.json as it causes a lot of noisy output during the installation process since it requires python.

--- a/packages/stentor-conditional/package.json
+++ b/packages/stentor-conditional/package.json
@@ -29,7 +29,6 @@
     "stentor-logger": "1.57.2"
   },
   "optionalDependencies": {
-    "isolated-vm": "4.4.2",
     "vm2": "3.9.11"
   },
   "peerDependencies": {


### PR DESCRIPTION
isolated-vm requires python and it throws a bunch of confusing console messages when you try to install.  We will still support it but this removes it from the optional dependency list so it doesn't install.