### PR TITLE
fix: Add matchConfidence to intent request events

### DIFF
--- a/packages/stentor-service-event/src/EventService.ts
+++ b/packages/stentor-service-event/src/EventService.ts
@@ -133,7 +133,10 @@ export class EventService implements ErrorService {
      */
     public request(request: Request): Event {
         // Pick out the necessary payload
-        let payload: any;
+        // by default it is just the request
+        let payload: any = {
+            request
+        }
         // depending on the request
         if (isInputUnknownRequest(request)) {
             payload = {
@@ -147,6 +150,9 @@ export class EventService implements ErrorService {
             };
             if (request.slots) {
                 payload.slots = request.slots;
+            }
+            if (request.matchConfidence) {
+                payload.matchConfidence = request.matchConfidence;
             }
         } else if (isAudioPlayerRequest(request)) {
             payload = {

--- a/packages/stentor-service-event/src/__test__/EventService.test.ts
+++ b/packages/stentor-service-event/src/__test__/EventService.test.ts
@@ -324,7 +324,9 @@ describe("EventService", () => {
             it("sets the payload", () => {
                 const request = new LaunchRequestBuilder().build();
                 const event = eventService.request(request);
-                expect(event.payload).to.be.undefined;
+                expect(event.payload).to.deep.equal({
+                    request
+                });
             });
         });
         describe("for an InputUnknown request", () => {


### PR DESCRIPTION
Match Confidence isn't showing up in studio, this adds it to the event purposely.