### PR TITLE
fix: NLUQueryResponse now includes KnowledgeBaseResult

### DIFF
--- a/packages/stentor-models/src/NLU/NLUService.ts
+++ b/packages/stentor-models/src/NLU/NLUService.ts
@@ -1,26 +1,21 @@
 /*! Copyright (c) 2019, XAPPmedia */
-import { InputUnknownRequestType, IntentRequestType, KnowledgeAnswer, RequestSlotMap, SentimentedRequest } from "../Request";
+import { IntentRequest, InputUnknownRequest } from "../Request";
 import { ActiveContext } from "../Response";
 
-export interface NLUQueryResponse extends SentimentedRequest {
-    type: IntentRequestType | InputUnknownRequestType;
-    /**
-     * ID for the matched intent.
-     */
-    intentId: string;
-    /**
-     * Optional slots for the matched intent.
-     */
-    slots?: RequestSlotMap;
-    /**
-     * Confidence level of the intent match.  On a scale from 0-1 where 1 is the highest confidence of a match.
-     */
-    matchConfidence?: number;
-    /**
-     * Some NLUs will also return knowledgebase results.
-     */
-    knowledgeAnswer?: KnowledgeAnswer;
-}
+/**
+ * Slightly smaller intent request without the sessionId and other identifying information.  It also doesn't pass through the original raw query.
+ */
+export type NLUIntentRequest = Pick<IntentRequest, "type" | "intentId" | "slots" | "matchConfidence" | "knowledgeAnswer" | "knowledgeBaseResult" | "sentimentAnalysis">
+
+/**
+ * Slightly smaller input unknown request without a sessionId and other identifying information.  It also doesn't pass through the original raw query.
+ */
+export type NLUInputUnknownRequest = Pick<InputUnknownRequest, "type" | "intentId" | "knowledgeBaseResult" | "sentimentAnalysis">;
+
+/**
+ * Response from the NLU
+ */
+export type NLUQueryResponse = NLUIntentRequest | NLUInputUnknownRequest;
 
 export interface NLURequestProps {
     /**


### PR DESCRIPTION
This updates the `NLUQueryResponse` to now be based on IntentRequest and InputknownRequest, which both contain the KnowledgeBaseResult.

This change will allow you to add the logic of when you call a KnowledgeBaseService to within a custom NLU instead of relying on the built-in logic.