### PR TITLE
fix: Initial Support for ChannelActionRequest

### DIFF
--- a/packages/stentor-runtime/src/__test__/main.channelactionrequest.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.channelactionrequest.test.ts
@@ -1,0 +1,151 @@
+/*! Copyright (c) 2021, XAPPmedia */
+import * as chai from "chai";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import { ConversationHandler } from "stentor-handler";
+import { HandlerFactory } from "stentor-handler-factory";
+import { ChannelActionRequest, Content, Event, EventStream, Handler, HandlerService, Storage, UserStorageService } from "stentor-models";
+import { EventService } from "stentor-service-event";
+
+import { main } from "../main";
+import { MockHandlerService, MockUserStorageService, passThroughChannel } from "./Mocks";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+const appId = "appId";
+
+const content: Content = {
+    ["IntentId"]: [
+        {
+            name: "Hello",
+            outputSpeech: "Hello ${f_name}",
+            conditions: `slotExists("f_name") && slotDoesNotExist("l_name")`
+        },
+        {
+            name: "Bye",
+            outputSpeech: "Bye ${f_name}"
+        },
+        {
+            name: "Hello F & L Name",
+            outputSpeech: "Hello ${f_name} ${l_name}",
+            conditions: `slotExists("f_name") && slotExists("l_name")`
+        },
+    ]
+};
+
+const handler: Handler = {
+    organizationId: "organizationId",
+    appId,
+    intentId: "IntentId",
+    name: "Intent Request",
+    type: "ConversationHandler",
+    content,
+    data: {}
+};
+
+const createdDate = new Date();
+createdDate.setDate(createdDate.getDate() - 1);
+
+const storage: Storage = {
+    createdTimestamp: createdDate.getTime(),
+    lastActiveTimestamp: createdDate.getTime()
+};
+
+/**
+ * Simple implementation of EventStream instrumented for testing.
+ */
+class TestEventStream implements EventStream {
+    public events: Event[] = [];
+    public flushed = false;
+
+    public addEvent(event: Event) {
+        this.events.push(event);
+    }
+
+    public async flush() {
+        this.flushed = true;
+    }
+}
+
+let request: ChannelActionRequest;
+let context: any;
+let handlerFactory: HandlerFactory;
+let callbackSpy: sinon.SinonSpy;
+let handlerService: HandlerService;
+let userStorageService: UserStorageService;
+
+let eventService: EventService;
+let eventStream: TestEventStream;
+
+describe("#main()", () => {
+    describe("for a ChannelActionRequest", () => {
+        beforeEach(() => {
+            handlerFactory = new HandlerFactory({ handlers: [ConversationHandler] });
+            context = {};
+            callbackSpy = sinon.spy();
+            handlerService = sinon.createStubInstance(MockHandlerService, {
+                get: handler
+            });
+            userStorageService = sinon.createStubInstance(MockUserStorageService, {
+                get: Promise.resolve(storage)
+            });
+
+            eventService = new EventService();
+            eventService.addPrefix({ appId });
+
+            eventStream = new TestEventStream();
+            eventService.addStream(eventStream);
+        });
+        afterEach(() => {
+            callbackSpy.resetHistory();
+        });
+        describe("for a handler that will not handle the event", () => {
+            beforeEach(async () => {
+
+                request = {
+                    type: "CHANNEL_ACTION_REQUEST",
+                    action: "OPEN_URL",
+                    uri: "https://xapp.ai/five-things-to-consider-before-building-an-intelligent-virtual-assistant",
+                    userId: "123",
+                    sessionId: "gbm-session-123",
+                    locale: "en-US",
+                    platform: "stentor-platform",
+                    channel: "widget"
+                };
+
+                await main(request, context, callbackSpy, [passThroughChannel()], {
+                    eventService,
+                    handlerFactory,
+                    handlerService,
+                    userStorageService
+                });
+            });
+            after(() => {
+                callbackSpy.resetHistory();
+            });
+            it("gets the storage for the user", async () => {
+                expect(userStorageService.get).to.have.been.calledOnce;
+                expect(userStorageService.get).to.have.been.calledWith(request.userId);
+            });
+            it("sets the proper events", () => {
+
+                expect(eventStream.events).to.have.length(2);
+                const requestEvent = eventStream.events[0];
+                expect(requestEvent.name).to.equal("CHANNEL_ACTION_REQUEST");
+                expect(requestEvent.platform).to.equal("stentor-platform");
+            });
+            it("returns the proper response", () => {
+                expect(callbackSpy).to.have.been.calledOnce;
+                // lets pull the argument out and inspect it a little
+                const callBackArgs = callbackSpy.getCall(0).args;
+                const error = callBackArgs[0];
+                expect(error).to.not.exist;
+                const payload = callBackArgs[1];
+                expect(payload).to.exist;
+                expect(payload).to.deep.equal({});
+            });
+        });
+    });
+});

--- a/packages/stentor-runtime/src/__test__/main.channelactionrequest.test.ts
+++ b/packages/stentor-runtime/src/__test__/main.channelactionrequest.test.ts
@@ -144,7 +144,7 @@ describe("#main()", () => {
                 expect(error).to.not.exist;
                 const payload = callBackArgs[1];
                 expect(payload).to.exist;
-                expect(payload).to.deep.equal({});
+                expect(payload).to.deep.equal({ "status": "complete" });
             });
         });
     });

--- a/packages/stentor-runtime/src/main.ts
+++ b/packages/stentor-runtime/src/main.ts
@@ -407,7 +407,7 @@ export const main = async (
         // We may change this behavior in the future.
         if (isChannelActionRequest(request)) {
             // special case
-            callback(null, {}, request, {});
+            callback(null, { status: "complete" }, request);
             return
         }
 

--- a/packages/stentor-runtime/src/main.ts
+++ b/packages/stentor-runtime/src/main.ts
@@ -232,8 +232,6 @@ export const main = async (
         return;
     }
 
-    // #0.55 Close out if we just have the 
-
     // #0.75 Use the NLU service if required by the channel
     if (channel.nlu) {
         // We don't call if it is a LaunchRequest, option, or permission grant

--- a/packages/stentor-runtime/src/main.ts
+++ b/packages/stentor-runtime/src/main.ts
@@ -179,6 +179,7 @@ export const main = async (
         return;
     }
 
+    // Report the event
     if (eventService) {
         // Look for overrides in the attributes field
         // Do this first
@@ -231,11 +232,13 @@ export const main = async (
         return;
     }
 
-    // #.75 Use the NLU service if required by the channel
+    // #0.55 Close out if we just have the 
+
+    // #0.75 Use the NLU service if required by the channel
     if (channel.nlu) {
         // We don't call if it is a LaunchRequest, option, or permission grant
-        if (!isLaunchRequest(request) 
-            && !isOptionSelectRequest(request) 
+        if (!isLaunchRequest(request)
+            && !isOptionSelectRequest(request)
             && !isPermissionRequest(request)
             && !isChannelActionRequest(request)) {
 
@@ -396,6 +399,20 @@ export const main = async (
         const manager = new HandlerManager({ service: handlerService, factory: handlerFactory });
         handler = await manager.from(request, context);
     } catch (error) {
+
+        // BETA 
+        // We are adding this check here so that we still give the handler an opportunity to
+        // return true to canHandleRequest
+        // If the handler returns false, it will then error out because the ChannelActionRequest
+        // does not have an intentId that is required to then request a new handler.
+        // In this case, we just return an empty payload.
+        // We may change this behavior in the future.
+        if (isChannelActionRequest(request)) {
+            // special case
+            callback(null, {}, request, {});
+            return
+        }
+
         // Add the error to the event service
         // We will not pass it out to the callback but we want to know about it.
         if (eventService) {


### PR DESCRIPTION
This adds very simple initial support for the new ChannelActionRequest.  This is subject to change but it is a start and it prevents the runtime environment from erroring.