### PR TITLE
fix: Reverts date-fns back to 2.29.2

### DIFF
--- a/packages/stentor-utils/package.json
+++ b/packages/stentor-utils/package.json
@@ -39,7 +39,7 @@
     "@types/xmldoc": "1.1.6",
     "blueimp-md5": "2.19.0",
     "chrono-node": "2.6.3",
-    "date-fns": "2.30.0",
+    "date-fns": "2.29.2",
     "dyno-item-size": "0.3.3",
     "fuse.js": "6.6.2",
     "html-entities": "2.3.3",

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
       "automerge": true
     },
     {
+      "packagePatterns": ["@microsoft", "@types"],
+      "schedule": ["after 9pm on sunday"],
+      "automerge": true
+    },
+    {
       "packageNames": ["aws-sdk"],
       "schedule": ["after 9pm on sunday"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,13 +163,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.21.0":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
-  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2386,12 +2379,10 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
-date-fns@2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
+date-fns@2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.2.tgz#0d4b3d0f3dff0f920820a070920f0d9662c51931"
+  integrity sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==
 
 dateformat@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
2.30.0 is missing a runtime dependency for babel. 