### PR TITLE
fix: Adds hasAnswer field to the generated KB answer

### DIFF
--- a/packages/stentor-models/src/Request/KnowledgeBase.ts
+++ b/packages/stentor-models/src/Request/KnowledgeBase.ts
@@ -129,6 +129,10 @@ export interface KnowledgeBaseGenerated extends KnowledgeBaseDocument {
      * Optional, the source LLM of the generated answer.
      */
     llm?: string;
+    /**
+     * Generated AI will still return an response even if it didn't have an answer.
+     */
+    hasAnswer?: boolean;
 }
 
 export interface KnowledgeBaseResult {


### PR DESCRIPTION
We need a way to determine if the LLM actually has an answer in the generated text or not since it will always generate text.