### PR TITLE
fix: Adding support for Generated KnowledgeBase Answers 

### DIFF
--- a/packages/stentor-runtime/src/combineKnowledgeBaseResults.ts
+++ b/packages/stentor-runtime/src/combineKnowledgeBaseResults.ts
@@ -25,7 +25,8 @@ export function combineKnowledgeBaseResults(existing: KnowledgeBaseResult, incom
         return {
             faqs: combine(existing?.faqs, incoming.faqs),
             documents: combine(existing?.documents, incoming.documents),
-            suggested: combine(existing?.suggested, incoming.suggested)
+            suggested: combine(existing?.suggested, incoming.suggested),
+            generated: combine(existing?.generated, incoming.generated)
         }
     } else {
         return incoming;


### PR DESCRIPTION
We didn't have it in the combine results function that puts it on the session variables.