### PR TITLE
fix: FAQ Prefiltering no longer default on StudioService

### DIFF
--- a/packages/stentor-models/src/Request/KnowledgeBase.ts
+++ b/packages/stentor-models/src/Request/KnowledgeBase.ts
@@ -91,9 +91,15 @@ export interface KnowledgeBaseSuggested extends KnowledgeBaseDocument {
  */
 export interface KnowledgeBaseFAQ {
     /**
-     * The question
+     * The question that is the closest match
      */
     question: string;
+    /**
+     * Optional, some FAQ based systems can return multiple questions that match to the same answer.  This will be populated if they exist.
+     * 
+     * There most likely be a duplicate of the question field.
+     */
+    questions?: string[];
     /**
      * URI, either the source or a location where more information can be found.
      */

--- a/packages/stentor-utils/src/__test__/matcher.test.ts
+++ b/packages/stentor-utils/src/__test__/matcher.test.ts
@@ -36,6 +36,19 @@ describe(`#${findFuzzyMatch.name}()`, () => {
             const matches = findFuzzyMatch("What is the capital of France?", ["How to reset password?", "Payment methods accepted", "Software installation guide"]);
             expect(matches).to.have.length(0);
         });
+        describe("and options are provided to return the closest", () => {
+            it("returns the closest match", () => {
+                const matches = findFuzzyMatch("what is your address", ["What is your location?", "Where are you located?", "How do I get to you?"], { threshold: 0.7 });
+                expect(matches[0]).to.equal("What is your location?");
+            });
+        });
+    });
+    describe("when the threshold is low (1.0)", () => {
+        it("will order the matches by closest match", () => {
+            const matches = findFuzzyMatch("what is your address", ["How do I get to you?", "What is your location?", "Where are you located?"], { threshold: 1.0 });
+            expect(matches).to.have.length(3);
+            expect(matches[0]).to.equal("What is your location?");
+        });
     });
 
     describe("when there are close matches", () => {

--- a/packages/stentor-utils/src/matcher.ts
+++ b/packages/stentor-utils/src/matcher.ts
@@ -62,6 +62,8 @@ const startsWithQuestionWord = (query: string): boolean => {
 /**
  * Uses cosine similarity to find all similar FAQs.
  * 
+ * In comparing similarity using cosine similarity, 0.0 is dissimilar and 1.0 is similar.
+ * 
  * @param query 
  * @param faqQuestions 
  * @param baseThreshold 
@@ -73,16 +75,10 @@ const findAllSimilarFAQs = (query: string, faqQuestions: string[], baseThreshold
     // Adjust threshold based on query type
     // if it does not start with a question word, lower the threshold
     // this lets "mayor of pawnee" match with "who is the mayor of pawnee"
-    // remember, number closer to 1.0 will means less close and 0.0 means exact match
     const threshold = startsWithQuestionWord(query) ? baseThreshold : baseThreshold * 0.8;
 
-    console.log(`Query: ${query}`);
-    console.log(`Threshold: ${threshold}`);
     faqQuestions.forEach(question => {
         const score = computeStringSimilarity(query, question);
-
-        //
-        console.log(`Score for ${question}: ${score}`);
 
         if (score >= threshold) {
             similarQuestions.push(question);

--- a/packages/stentor-utils/src/matcher.ts
+++ b/packages/stentor-utils/src/matcher.ts
@@ -145,8 +145,6 @@ export function findFuzzyMatch<T = string | Record<string, unknown>>(find: strin
     const fuse = new FuseConstructor(from, fuseOptions);
     const result: Fuse.FuseResult<T>[] = fuse.search(find); // Literal here is to turn numbers to strings
 
-    console.log(result);
-
     matches = result.map((result) => {
         return from[result.refIndex];
     });
@@ -159,8 +157,6 @@ export function findFuzzyMatch<T = string | Record<string, unknown>>(find: strin
         // so if a threshold is provided we need to flip it
         const similarThreshold: number | undefined = options.threshold ? 1 - options.threshold : undefined;
         matches = findAllSimilarFAQs(find, matches as string[], similarThreshold) as T[];
-        console.log('Filtered matches');
-        console.log(matches);
     }
 
     return matches;

--- a/packages/stentor-utils/src/string/__test__/compare.test.ts
+++ b/packages/stentor-utils/src/string/__test__/compare.test.ts
@@ -1,0 +1,11 @@
+/*! Copyright (c) 2023, XAPP AI */
+import { expect } from "chai";
+
+import { compareStrings } from "../compare";
+
+describe(`#${compareStrings.name}()`, () => {
+    it("compares correctly", () => {
+        expect(compareStrings('what is a conversational ai platform', 'What is a conversational AI platform?')).to.be.true;
+        expect(compareStrings("what is your name", "what height are you")).to.be.false;
+    });
+});

--- a/packages/stentor-utils/src/string/compare.ts
+++ b/packages/stentor-utils/src/string/compare.ts
@@ -1,0 +1,36 @@
+/*! Copyright (c) 2023, XAPP AI */
+
+const stopWords = new Set([
+    "a", "an", "and", "are", "as", "at", "be", "but", "by",
+    "for", "if", "in", "into", "is", "it",
+    "no", "not", "of", "on", "or", "such",
+    "that", "the", "their", "then", "there", "these",
+    "they", "this", "to", "was", "will", "with"
+]);
+
+function cleanString(input: string): string {
+    const regex = /[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]/g;
+    const words = input.replace(regex, "").toLowerCase().split(/\s+/);
+    const filteredWords = words.filter(word => !stopWords.has(word));
+    return filteredWords.join(" ");
+}
+
+/**
+ * Compares two strings for loose equality.  
+ * 
+ * It will clean punctuation, lowercase, and remove all stop words for both the strings and then compare them for equality.
+ * 
+ * It allows a string like "What is conversational AI" to equal "What are conversational AI?".
+ * 
+ * @param one 
+ * @param two 
+ * @returns True if the sentences are basically the same.
+ */
+export function compareStrings(one: string, two: string): boolean {
+
+    const cleanOne = cleanString(one);
+    const cleanTwo = cleanString(two);
+
+    return cleanOne === cleanTwo;
+
+}

--- a/packages/stentor-utils/src/string/index.ts
+++ b/packages/stentor-utils/src/string/index.ts
@@ -1,6 +1,7 @@
 /*! Copyright (c) 2019, XAPPmedia */
 export * from "./capitalize";
 export * from "./cleanTags";
+export * from "./compare";
 export * from "./randomString";
 export * from "./removePostFix";
 export * from "./StringExpander";


### PR DESCRIPTION
Our prefilter on the FAQs is no longer necessary as we are now passing these results to an LLM, which will better determine if they are relevant or not.  The old behavior can still be used through a construction property.