### PR TITLE
fix: Adding sessionId & userId to ExternalLead

### DIFF
--- a/packages/stentor-models/src/Crm.ts
+++ b/packages/stentor-models/src/Crm.ts
@@ -1,8 +1,6 @@
 /*! Copyright (c) 2022, XAPPmedia */
 import { Message } from "./Message";
 
-
-
 export interface LeadFormField {
     name: string;
     value: string;
@@ -10,10 +8,24 @@ export interface LeadFormField {
 
 export interface ExternalLead {
     /**
+     * The user ID that generated the lead
+     */
+    userId?: string;
+    /**
+     * The session ID that generated the lead
+     */
+    sessionId?: string;
+    /**
      * Fields such as name and email
      */
     fields: LeadFormField[];
+    /**
+     * Optional source, typically chat-widget or form-widget
+     */
     source?: string;
+    /**
+     * Optional company
+     */
     company?: string;
     /**
      * Transcript of the conversation
@@ -21,7 +33,7 @@ export interface ExternalLead {
      */
     transcript?: Message[];
     /**
-     * Optional reference ID
+     * Optional reference ID in the 3rd party CRM or FSM
      */
     refId?: string;
     /**


### PR DESCRIPTION
We can use these to keep track of sessionId and userId in our lead system for later lookup.