### PR TITLE
fix: Better Error Messages in Studio HandlerService

### DIFF
--- a/packages/stentor-handler-manager/src/HandlerManager.ts
+++ b/packages/stentor-handler-manager/src/HandlerManager.ts
@@ -123,11 +123,12 @@ export class HandlerManager {
                 const props = await this.service.get(id);
                 handler = this.factory.fromProps(props);
             } catch (error) {
-                log().warn(`Unable to get valid handler for ${id}`);
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                log().warn(`Unable to get valid handler for ${id}: ${errorMessage}`);
                 if (error instanceof NoHandlerClassError) {
                     console.error(error.message);
                 } else {
-                    console.error(error);
+                    console.error(errorMessage);
                 }
             }
         }
@@ -158,7 +159,8 @@ export class HandlerManager {
                 handler = this.factory.fromProps(props);
             } catch (error) {
                 // log and move on
-                log().info(error);
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                log().warn(`Unable to get InputUnknown handler: ${errorMessage}`);
             }
 
             // If we got one from the DB, transform the request
@@ -217,7 +219,8 @@ export class HandlerManager {
                         const props = await this.service.get(id);
                         handler = this.factory.fromProps(props);
                     } catch (error) {
-                        log().info(`Unable to get valid handler for ${id}.  Error: ${error.message}`);
+                        const errorMessage = error instanceof Error ? error.message : String(error);
+                        log().warn(`Unable to get valid handler for ${id}.  Error: ${errorMessage}`);
                     }
 
                     if (!handler) {

--- a/packages/stentor-service-ovai/src/__test__/OVAIService.test.ts
+++ b/packages/stentor-service-ovai/src/__test__/OVAIService.test.ts
@@ -79,4 +79,151 @@ describe("OVAIService", () => {
             });
         });
     });
+    describe("#get()", () => {
+        let service: OVAIService;
+        beforeEach(() => {
+            service = new OVAIService({
+                appId: "appId",
+                token: "token"
+            });
+        });
+        afterEach(() => {
+            fetchMock.reset();
+        });
+        after(() => {
+            fetchMock.restore();
+        });
+        describe("when handler exists", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.media/cms/handler/TestIntent",
+                    {
+                        handler: {
+                            intentId: "TestIntent",
+                            name: "Test Handler",
+                            type: "ConversationHandler"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("returns the handler", async () => {
+                const handler = await service.get("TestIntent");
+                expect(handler).to.exist;
+                expect(handler.intentId).to.equal("TestIntent");
+            });
+        });
+        describe("when handler does not exist (404)", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.media/cms/handler/NonExistentIntent",
+                    {
+                        status: 404,
+                        body: {
+                            errorType: "HandledError",
+                            httpStatus: 404,
+                            message: "Handler not found."
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_404",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("throws an error with intentId", async () => {
+                try {
+                    await service.get("NonExistentIntent");
+                    expect.fail("Should have thrown an error");
+                } catch (error) {
+                    expect(error.message).to.include("NonExistentIntent");
+                    expect(error.message).to.include("not found");
+                    expect(error.message).to.include("Please verify the intentId exists");
+                }
+            });
+        });
+        describe("when unauthorized (401)", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.media/cms/handler/TestIntent",
+                    {
+                        status: 401,
+                        body: {
+                            message: "Unauthorized"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_401",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("throws an unauthorized error", async () => {
+                try {
+                    await service.get("TestIntent");
+                    expect.fail("Should have thrown an error");
+                } catch (error) {
+                    expect(error.message).to.include("Token provided to OVAIService is unauthorized");
+                }
+            });
+        });
+        describe("when server error (500)", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.media/cms/handler/TestIntent",
+                    {
+                        status: 500,
+                        body: {
+                            message: "Internal Server Error"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_500",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("throws an error with status code", async () => {
+                try {
+                    await service.get("TestIntent");
+                    expect.fail("Should have thrown an error");
+                } catch (error) {
+                    expect(error.message).to.include("OVAIService.get()");
+                    expect(error.message).to.include("500");
+                    expect(error.message).to.include("TestIntent");
+                }
+            });
+        });
+        describe("when passed intentId as object", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.media/cms/handler/ObjectIntent",
+                    {
+                        handler: {
+                            intentId: "ObjectIntent",
+                            name: "Object Test Handler",
+                            type: "ConversationHandler"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_OBJECT",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("extracts the intentId and returns the handler", async () => {
+                const handler = await service.get({ intentId: "ObjectIntent" });
+                expect(handler).to.exist;
+                expect(handler.intentId).to.equal("ObjectIntent");
+            });
+        });
+    });
 });

--- a/packages/stentor-service-studio/src/__test__/StudioService.test.ts
+++ b/packages/stentor-service-studio/src/__test__/StudioService.test.ts
@@ -126,4 +126,181 @@ describe(`${StudioService.name}`, () => {
             });
         });
     });
+    describe("#get()", () => {
+        let service: StudioService;
+        beforeEach(() => {
+            service = new StudioService({
+                appId: "appId",
+                token: "token"
+            });
+        });
+        afterEach(() => {
+            fetchMock.reset();
+        });
+        after(() => {
+            fetchMock.restore();
+        });
+        describe("when handler exists", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.ai/cms/handler/TestIntent",
+                    {
+                        handler: {
+                            intentId: "TestIntent",
+                            name: "Test Handler",
+                            type: "ConversationHandler"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("returns the handler", async () => {
+                const handler = await service.get("TestIntent");
+                expect(handler).to.exist;
+                expect(handler.intentId).to.equal("TestIntent");
+            });
+        });
+        describe("when handler does not exist (404)", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.ai/cms/handler/NonExistentIntent",
+                    {
+                        status: 404,
+                        body: {
+                            errorType: "HandledError",
+                            httpStatus: 404,
+                            message: "Handler not found."
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_404",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("throws an error with intentId", async () => {
+                try {
+                    await service.get("NonExistentIntent");
+                    expect.fail("Should have thrown an error");
+                } catch (error) {
+                    expect(error.message).to.include("NonExistentIntent");
+                    expect(error.message).to.include("not found");
+                    expect(error.message).to.include("Please verify the intentId exists");
+                }
+            });
+        });
+        describe("when unauthorized (401)", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.ai/cms/handler/TestIntent",
+                    {
+                        status: 401,
+                        body: {
+                            message: "Unauthorized"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_401",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("throws an unauthorized error", async () => {
+                try {
+                    await service.get("TestIntent");
+                    expect.fail("Should have thrown an error");
+                } catch (error) {
+                    expect(error.message).to.include("Token provided to StudioService is unauthorized");
+                }
+            });
+        });
+        describe("when server error (500)", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.ai/cms/handler/TestIntent",
+                    {
+                        status: 500,
+                        body: {
+                            message: "Internal Server Error"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_500",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("throws an error with status code", async () => {
+                try {
+                    await service.get("TestIntent");
+                    expect.fail("Should have thrown an error");
+                } catch (error) {
+                    expect(error.message).to.include("StudioService.get()");
+                    expect(error.message).to.include("500");
+                    expect(error.message).to.include("TestIntent");
+                }
+            });
+        });
+        describe("when passed intentId as object", () => {
+            beforeEach(() => {
+                fetchMock.get(
+                    "https://api.xapp.ai/cms/handler/ObjectIntent",
+                    {
+                        handler: {
+                            intentId: "ObjectIntent",
+                            name: "Object Test Handler",
+                            type: "ConversationHandler"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_OBJECT",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("extracts the intentId and returns the handler", async () => {
+                const handler = await service.get({ intentId: "ObjectIntent" });
+                expect(handler).to.exist;
+                expect(handler.intentId).to.equal("ObjectIntent");
+            });
+        });
+        describe("with orgToken", () => {
+            beforeEach(() => {
+                service = new StudioService({
+                    appId: "appId",
+                    token: "token",
+                    orgToken: "orgToken"
+                });
+                fetchMock.get(
+                    "https://api.xapp.ai/cms/handler/TestIntent?appId=appId",
+                    {
+                        handler: {
+                            intentId: "TestIntent",
+                            name: "Test Handler with Org Token",
+                            type: "ConversationHandler"
+                        }
+                    },
+                    {
+                        name: "GET_HANDLER_ORG",
+                        method: "GET",
+                        overwriteRoutes: true
+                    }
+                );
+            });
+            it("includes appId in query params", async () => {
+                const handler = await service.get("TestIntent");
+                expect(handler).to.exist;
+                expect(handler.intentId).to.equal("TestIntent");
+                expect(fetchMock.called()).to.be.true;
+            });
+        });
+    });
 });


### PR DESCRIPTION
When an error would occur, we would return undefined, which isn't always helpful.