### PR TITLE
feat: add maxLength property to FormDropdownInput interface

### DIFF
--- a/packages/stentor-models/src/Form/FormField.ts
+++ b/packages/stentor-models/src/Form/FormField.ts
@@ -192,6 +192,10 @@ export interface FormDropdownInput extends FormInput {
    * List of items available for selection in the dropdown
    */
   items: SelectableItem[];
+  /**
+   * Maximum character length allowed for freeform text input (e.g., "other" option)
+   */
+  maxLength?: number;
 }
 
 /**


### PR DESCRIPTION
Add optional maxLength property to support character limits for freeform text input in dropdown 'other' options.

Fixes #2824

Generated with [Claude Code](https://claude.ai/code)