### PR TITLE
feat: add startTime and endTime fields to SelectableItem interface

### DIFF
--- a/packages/stentor-models/src/Form/FormField.ts
+++ b/packages/stentor-models/src/Form/FormField.ts
@@ -430,4 +430,12 @@ export interface SelectableItem {
    * When true, the item will be shown as selected by default
    */
   selected?: boolean;
+  /**
+   * Optional start time for time window chips (e.g., "10:00" in 24-hour format or ISO time)
+   */
+  startTime?: string;
+  /**
+   * Optional end time for time window chips (e.g., "18:00" in 24-hour format or ISO time)
+   */
+  endTime?: string;
 }


### PR DESCRIPTION
Add optional startTime and endTime string fields to SelectableItem interface to support time window chips for ServiceTitan integration. These fields enable form-widget to pass specific appointment times instead of relying on hardcoded mappings in consuming services.

Fixes #2979

Generated with [Claude Code](https://claude.ai/code)