### PR TITLE
fix(stentor-logger): fix chalk import to prevent __importStar wrapper issue

### DIFF
--- a/packages/stentor-logger/src/logger.ts
+++ b/packages/stentor-logger/src/logger.ts
@@ -1,7 +1,7 @@
 /*! Copyright (c) 2019, XAPPmedia */
 
 import { maskEmails, maskPhoneNumbers } from "stentor-utils";
-import * as chalk from "chalk";
+import chalk from "chalk";
 
 // Winston types - these will be available if Winston is installed
 interface WinstonTransformableInfo {


### PR DESCRIPTION
Fixes #2990

Changes the chalk import from `import * as chalk` to `import chalk` to resolve the TypeError: chalk.red is not a function issue.

With esModuleInterop: true in tsconfig, this generates __importDefault instead of __importStar, correctly preserving chalk's function exports (.red, .green, etc.).

Generated with [Claude Code](https://claude.ai/code)