### PR TITLE
Add requireSelection to FormFieldTextAddressInput

### DIFF
--- a/packages/stentor-models/src/Form/FormField.ts
+++ b/packages/stentor-models/src/Form/FormField.ts
@@ -143,6 +143,11 @@ export interface FormFieldTextAddressInput extends FormTextInput {
    * Not needed if using a custom proxy endpoint that handles authentication.
    */
   googleMapsApiKey?: string;
+  /**
+   * When true, the user must select an address from the autocomplete suggestions.
+   * Free-text entry is not allowed. Defaults to false (free-text allowed).
+   */
+  requireSelection?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add optional `requireSelection` boolean to `FormFieldTextAddressInput` interface that controls whether users must select from autocomplete dropdown or can enter free text.

Fixes #3040

Generated with [Claude Code](https://claude.ai/code)