### PR TITLE
ci: run docs build on PRs to catch website regressions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,12 @@ on:
       - 'website/**'
       - 'packages/*/src/**'
       - '.github/workflows/deploy-docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'website/**'
+      - 'packages/*/src/**'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -50,6 +56,7 @@ jobs:
           yarn build
 
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger to `.github/workflows/deploy-docs.yml` (same path filters as the existing `push` to master trigger), so the Docusaurus website build runs on PRs touching `docs/**`, `website/**`, `packages/*/src/**`, or the workflow itself.
- Gates the `Deploy to GitHub Pages` step to `push` events on `master` so PR runs validate the build without publishing.

## Why
#3029 bumped `@docusaurus/core` to v3 but left `@mdx-js/react` at v1. The website build broke and only surfaced on the post-merge `Deploy Documentation` run on master (#3042 fixed it). CircleCI's PR-level `build` job (which runs `lerna run build`) reported green for #3029 — likely an Nx task-cache hit on `website:build`, since the change was outside `packages/`. There was no PR-level check that actually exercised `cd website && yarn build`, so the regression slipped through review.

## Test plan
- [ ] This PR itself touches `.github/workflows/deploy-docs.yml`, so the workflow should run here and build the docs without publishing.
- [ ] After merge, the next push to `master` should run the full workflow including the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)