### PR TITLE
ci: fetch release branch before checkout in release-lockfile

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,8 +64,14 @@ jobs:
                     echo "found=false" >> "$GITHUB_OUTPUT"
                     echo "No release branch open; nothing to do."
                   fi
+            # actions/checkout only fetched master, so the release branch ref is not
+            # in the local clone — fetch it explicitly before checking it out, or
+            # `git checkout <branch>` fails with "pathspec did not match".
             - if: steps.branch.outputs.found == 'true'
-              run: git checkout "${{ steps.branch.outputs.name }}"
+              run: |
+                  set -euo pipefail
+                  git fetch origin "${{ steps.branch.outputs.name }}:${{ steps.branch.outputs.name }}"
+                  git checkout "${{ steps.branch.outputs.name }}"
             - if: steps.branch.outputs.found == 'true'
               uses: actions/setup-node@v4
               with:
@@ -85,7 +91,7 @@ jobs:
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                   git add yarn.lock
                   git commit -m "chore: regenerate yarn.lock for release"
-                  git push
+                  git push origin HEAD:"${{ steps.branch.outputs.name }}"
 
     publish:
         needs: release-please


### PR DESCRIPTION
Follow-up to the CI migration (#3108). The first release-please run opened release PR #3109 but the **`release-lockfile` job failed**, and this is the job whose entire job is to keep a stale lockfile off master — so this needs to land before #3109 merges.

## The bug

`actions/checkout` only fetches the triggering ref (master). The job then detected the release branch with `git ls-remote` (which queries the remote, not the local clone) and ran `git checkout <branch>` — which failed with `pathspec 'release-please--branches--master' did not match` because that ref was never fetched locally. The job died before regenerating yarn.lock.

## Why it's not cosmetic here

These packages pin each other by **concrete version** (`"stentor-models": "1.73.0"`), not `workspace:*`. release-please's `node-workspace` plugin rewrote every one of those ranges to `1.74.0` in #3109 but left `yarn.lock` untouched. The lockfile is genuinely stale, so merging #3109 as-is would break `yarn install --immutable` (YN0028) on every subsequent PR. Verified against the #3109 branch diff.

## Fix

- `git fetch origin <branch>:<branch>` before `git checkout <branch>`.
- Push back with `git push origin HEAD:<branch>` — a branch created via a `src:dst` refspec has no upstream, so the bare `git push` would have failed too.

## After this merges

Merging this pushes to master, which re-runs release-please; the fixed `release-lockfile` will find #3109's branch and commit the regenerated `yarn.lock` to it. Then #3109 is safe to merge. **Do not merge #3109 until its `release-lockfile` run is green.**

Note: this bug is latent in chat-widget's copy of the job too — it just hasn't had a release exercise it yet. Worth porting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)