### PR TITLE
ci: hold renovate updates 3 days to clear npm quarantine

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": ["config:base", "schedule:daily"],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "depTypeList": ["devDependencies"],


### PR DESCRIPTION
## Why

`stentorium/stentor` is **public**, so Yarn 4 auto-enables **hardened mode** on PR installs (`"executed from a public pull request"`). Hardened mode rejects freshly-published npm versions still in npm's quarantine window:

```
YN0016: knip@npm:6.27.0: All versions satisfying "6.27.0" are quarantined
YN0016: @aws-sdk/client-firehose@npm:3.1088.0: All versions satisfying "3.1088.0" are quarantined
```

So every renovate/dependabot PR that bumps to a same-day release fails `yarn install --immutable` across all four CI jobs. This is new since the CircleCI→GitHub Actions migration — CircleCI didn't trip Yarn's public-PR detection, and the other (private) repos never enable hardened mode at all.

## Change

Two top-level keys in `renovate.json`:

- `minimumReleaseAge: "3 days"` — Renovate only proposes versions that have aged well past npm's quarantine window.
- `internalChecksFilter: "strict"` — holds the branch back entirely until the age passes, so the PR is **never opened** during quarantine (rather than opened with a pending check).

Bonus: 3-day aging is also a supply-chain safeguard — skips versions that get unpublished or flagged shortly after release.

Validated with `renovate-config-validator` → *Config validated successfully*.

## Scope / notes

- Global, so it covers the grouped `@xapp` and `aws-sdk` rules too.
- Does **not** retroactively fix the already-open red PRs (#3112 etc.) — those exist already; re-run or let Renovate rebase them once their versions age out. New PRs won't hit the quarantine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)