### PR TITLE
chore: add repository metadata to packages for npm provenance

### DIFF
--- a/packages/stentor-address/package.json
+++ b/packages/stentor-address/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-address",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-address"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-channel/package.json
+++ b/packages/stentor-channel/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-channel",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-channel"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-conditional/package.json
+++ b/packages/stentor-conditional/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-conditional",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-conditional"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-constants/package.json
+++ b/packages/stentor-constants/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-constants",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-constants"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-context/package.json
+++ b/packages/stentor-context/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-context",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-context"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-determiner/package.json
+++ b/packages/stentor-determiner/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-determiner",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-determiner"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-guards/package.json
+++ b/packages/stentor-guards/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-guards",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-guards"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-handler-delegating/package.json
+++ b/packages/stentor-handler-delegating/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-handler-delegating",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-handler-delegating"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-handler-factory/package.json
+++ b/packages/stentor-handler-factory/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-handler-factory",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-handler-factory"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-handler-manager/package.json
+++ b/packages/stentor-handler-manager/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-handler-manager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-handler-manager"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-handler/package.json
+++ b/packages/stentor-handler/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-handler",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-handler"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-history/package.json
+++ b/packages/stentor-history/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-history",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-history"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-interaction-model/package.json
+++ b/packages/stentor-interaction-model/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-interaction-model",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-interaction-model"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-locales/package.json
+++ b/packages/stentor-locales/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-locales",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-locales"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-logger/package.json
+++ b/packages/stentor-logger/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-logger",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-logger"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-media/package.json
+++ b/packages/stentor-media/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-media",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-media"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-models/package.json
+++ b/packages/stentor-models/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-models",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-models"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-request/package.json
+++ b/packages/stentor-request/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-request",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-request"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-response/package.json
+++ b/packages/stentor-response/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-response",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-response"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-runtime/package.json
+++ b/packages/stentor-runtime/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-runtime",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-runtime"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-service-event/package.json
+++ b/packages/stentor-service-event/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-service-event",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-service-event"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-service-fetch/package.json
+++ b/packages/stentor-service-fetch/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-service-fetch",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-service-fetch"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-service-ovai/package.json
+++ b/packages/stentor-service-ovai/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-service-ovai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-service-ovai"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-service-studio/package.json
+++ b/packages/stentor-service-studio/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-service-studio",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-service-studio"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-storage/package.json
+++ b/packages/stentor-storage/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-storage",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-storage"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-time/package.json
+++ b/packages/stentor-time/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-time",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-time"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-user-storage-dynamo/package.json
+++ b/packages/stentor-user-storage-dynamo/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-user-storage-dynamo",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-user-storage-dynamo"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor-utils/package.json
+++ b/packages/stentor-utils/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor-utils"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/stentor/package.json
+++ b/packages/stentor/package.json
@@ -1,5 +1,10 @@
 {
   "name": "stentor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stentorium/stentor.git",
+    "directory": "packages/stentor"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Why

The `1.74.0` release created all 29 tags but **published nothing** — the publish job failed on the first package:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/stentor
Error verifying sigstore provenance bundle: package.json: "repository.url" is "",
expected to match "https://github.com/stentorium/stentor" from provenance
```

`npm publish --provenance` requires **every published package** to declare a `repository` whose URL matches the source repo. The root `package.json` has one, but the individual packages did not.

(OIDC/trusted-publishing itself is fine — E422 happens at the registry PUT, *after* auth succeeded.)

## Change

Add a `repository` block with monorepo `directory` to all 29 published packages:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/stentorium/stentor.git",
  "directory": "packages/<name>"
}
```

No dependency changes → `yarn.lock` untouched.

## Why `chore:` and not `fix:`

The `1.74.0` tags already exist. A `fix:`/`feat:` commit would make release-please open a new release PR bumping everything to `1.74.1` and strand `1.74.0`. As a `chore` it triggers no version bump, so **`1.74.0` stays the target** and gets published from `master` via the `release-please.yml` `workflow_dispatch` escape hatch once this merges.

## After merge

Dispatch `release-please.yml` with the 29 released package dirs to publish `1.74.0`. Nothing published yet, so there are no version collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)