### PR TITLE
ci: serialize release runs to prevent lockfile push race

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,15 @@ permissions:
     pull-requests: write
     id-token: write
 
+# Serialize release runs per ref. Back-to-back pushes to master (e.g. two
+# renovate/dependabot PRs merged in quick succession) would otherwise race:
+# the later run's `git push` of the regenerated yarn.lock to the release
+# branch could fail non-fast-forward. Queue rather than cancel so an in-flight
+# publish is never interrupted mid-release.
+concurrency:
+    group: release-please-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     release-please:
         if: github.event_name == 'push'


### PR DESCRIPTION
## Why

Back-to-back pushes to `master` (e.g. two renovate/dependabot PRs merged in quick succession) can spawn overlapping `release-please` runs. The later run's `git push` of the regenerated `yarn.lock` to the release branch could then fail **non-fast-forward**. Low blast radius (rerun fixes it, no corruption), but avoidable.

## Change

Add a workflow-level concurrency group so release runs queue instead of racing:

```yaml
concurrency:
    group: release-please-${{ github.ref }}
    cancel-in-progress: false
```

`cancel-in-progress: false` so a queued run never interrupts an in-flight publish mid-release.

Backport of the guard added to `XappMedia/stentor-core` (#5235). Workflow-only change; `yaml.safe_load` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)