### PR TITLE
fix(stentor-utils): pin xmldoc to 2.0.3 (CommonJS) to stop ESM require crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "version-check:all": "syncpack list-mismatches --types dev,prod",
     "knip": "knip"
   },
+  "resolutions": {
+    "xmldoc": "2.0.3"
+  },
   "packageManager": "yarn@4.17.1"
 }

--- a/packages/stentor-utils/package.json
+++ b/packages/stentor-utils/package.json
@@ -61,7 +61,7 @@
     "stentor-constants": "1.74.0",
     "stentor-guards": "1.74.0",
     "words-to-numbers": "1.5.1",
-    "xmldoc": "3.0.0"
+    "xmldoc": "2.0.3"
   },
   "peerDependencies": {
     "stentor-models": "1.x"

--- a/packages/stentor-utils/src/ssml.test.ts
+++ b/packages/stentor-utils/src/ssml.test.ts
@@ -1,0 +1,38 @@
+/*! Copyright (c) 2019, XAPPmedia */
+
+import { expect } from "chai";
+import { cleanInvalid, isValidSSML } from "./ssml";
+
+// These tests double as a regression guard for the `xmldoc` dependency: `ssml.ts` does a
+// top-level `require("xmldoc")`, so if `xmldoc` is ever bumped to an ESM-only release (>=3.0.0),
+// merely importing this module throws `ERR_REQUIRE_ESM` and every test below fails to even load.
+// Keep `xmldoc` on the 2.x CommonJS line (see renovate.json).
+describe("ssml", () => {
+    describe("cleanInvalid()", () => {
+        it("loads the xmldoc-backed module and parses SSML without throwing", () => {
+            expect(() => cleanInvalid("<speak>Ben and Jerry</speak>")).to.not.throw();
+        });
+
+        it("restores '&' inside an <audio> src after normalizing '&' to ' and '", () => {
+            const input = `<speak>Ben & Jerry <audio src="https://x.io/a.mp3?u=1&v=2"/></speak>`;
+            const result = cleanInvalid(input);
+
+            // The '&' in the audio query string round-trips through XmlDocument back to '&'...
+            expect(result).to.contain("u=1&v=2");
+            expect(result).to.not.contain("u=1 and v=2");
+            // ...while a '&' in plain text stays converted to ' and '.
+            expect(result).to.contain("Ben and Jerry");
+        });
+
+        it("leaves speech without an '&' untouched", () => {
+            const input = "<speak>Nothing to clean here</speak>";
+            expect(cleanInvalid(input)).to.equal(input);
+        });
+    });
+
+    describe("isValidSSML()", () => {
+        it("is callable (constructs an XmlDocument) without throwing at module load", () => {
+            expect(() => isValidSSML("<speak>hello</speak>")).to.not.throw();
+        });
+    });
+});

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
     {
       "packageNames": ["aws-sdk"],
       "schedule": ["after 9pm on sunday"]
+    },
+    {
+      "description": "xmldoc 3.x is ESM-only; stentor-utils require()s it from CommonJS, so >=3 breaks every downstream Lambda at init (ERR_REQUIRE_ESM). Stay on the 2.x CJS line.",
+      "matchPackageNames": ["xmldoc"],
+      "allowedVersions": "<3.0.0"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19087,17 +19087,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:^1.4.3":
+  version: 1.6.0
+  resolution: "sax@npm:1.6.0"
+  checksum: 10c0/e5593f4a91eb25761a688c4d96902e4e95a0dd6017bc65146b6f21236e3d715cf893333b76bc758923c9574c2fb5a7a76c3a81e96ea15432f2624f906c027c1e
+  languageName: node
+  linkType: hard
+
 "sax@npm:^1.5.0":
   version: 1.5.0
   resolution: "sax@npm:1.5.0"
   checksum: 10c0/bc3b60a7bfecd40b18256596e96b32df2488339ae1e00a77f842b568f0831228a16c3bd357ec500241ec0b9dc7a475a1286427795c4a8c50bb8e8878f3435dd8
-  languageName: node
-  linkType: hard
-
-"sax@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "sax@npm:1.6.0"
-  checksum: 10c0/e5593f4a91eb25761a688c4d96902e4e95a0dd6017bc65146b6f21236e3d715cf893333b76bc758923c9574c2fb5a7a76c3a81e96ea15432f2624f906c027c1e
   languageName: node
   linkType: hard
 
@@ -20553,7 +20553,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     typescript: "npm:6.0.3"
     words-to-numbers: "npm:1.5.1"
-    xmldoc: "npm:3.0.0"
+    xmldoc: "npm:2.0.3"
   peerDependencies:
     stentor-models: 1.x
   languageName: unknown
@@ -22533,12 +22533,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xmldoc@npm:*, xmldoc@npm:3.0.0":
-  version: 3.0.0
-  resolution: "xmldoc@npm:3.0.0"
+"xmldoc@npm:2.0.3":
+  version: 2.0.3
+  resolution: "xmldoc@npm:2.0.3"
   dependencies:
-    sax: "npm:^1.6.0"
-  checksum: 10c0/6369d059f425aea9b04caecf3d38626e82d08a8bd2aef57b8ae7b248a39be5264b8736ae70706d3b5d433c1a605e6b05b226b26e2dc95ac295864c68319e9c13
+    sax: "npm:^1.4.3"
+  checksum: 10c0/8b01fc2b49f7dfa3fc0506d7ae4bab41476e15836114a1ab3794a5dc925498e2f4c248391479f57426e166a718082e6628c7112a89e6bf015ed780c9772f4406
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## The bug

`stentor-utils`' `ssml.ts` does a top-level `require("xmldoc")`, but the dependency was pinned to **`xmldoc@3.0.0`**, which is **ESM-only** (`type: module`, no CommonJS entry point). Any CommonJS consumer — i.e. **every Stentor Lambda** — then crashes at **init**:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../xmldoc/dist/index.js
from .../stentor-utils/lib/ssml.js not supported.
```

API Gateway returns **502** for every request. This took down `stentor-api` **dev** right after the 1.73.0/1.74.0 `stentor-*` family landed, and would hit stage/prod on their next deploy.

## The fix

Pin `xmldoc` to **`2.0.3`** — the latest release still shipped as CommonJS (2.x is `type: commonjs`; only 3.0.0 went ESM). Notes:

- `ssml.ts` only uses `new XmlDocument()`, `childrenNamed`, `node.attr`, and `toString({ preserveWhitespace, compressed })` — all identical across xmldoc 2.x and 3.x, so this is API-safe.
- Realigns runtime with the already-present `@types/xmldoc@2.0.0` (they were mismatched: types 2.x, runtime 3.x).

## Regression guards

- **`renovate.json`** caps `xmldoc` at `<3.0.0`, so it isn't silently auto-bumped back to the ESM major.
- **`ssml.test.ts`** exercises `cleanInvalid()` / `isValidSSML()`. Because `ssml.ts` `require()`s xmldoc at module top-level, merely importing the test module throws `ERR_REQUIRE_ESM` if xmldoc is ever ESM again — so CI fails loudly. Verified locally against `xmldoc@2.0.3`: `require` loads, and `cleanInvalid` round-trips an `<audio>` src `&` correctly.

## Downstream

`stentor-api` currently pins `xmldoc` to `1.3.0` via `resolutions` as an emergency stopgap (its PR #5552). That workaround can be dropped once this publishes and stentor-api bumps to the new `stentor-utils`.